### PR TITLE
Sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,29 @@ $c= new MongoConnection('mongodb+srv://server.example.com');
 $c->connect();
 ```
 
+Sessions
+--------
+Using a causally consistent session, an application can read its own writes and is guaranteed monotonic reads, even when reading from replica set secondaries.
+
+```php
+use com\mongodb\{MongoConnection, ObjectId, Operations};
+use util\cmd\Console;
+
+$c= new MongoConnection('mongodb+srv://server.example.com?readPreference=secondary');
+$session= $c->session();
+
+$id= new ObjectId('...');
+
+// Will write to primary
+$collection= $c->collection('test.products');
+$collection->update($id, ['$set' => ['qty' => 1]], $session);
+
+// Will read the updated document
+$updated= $collection->find($id, $session);
+
+$session->close();
+```
+
 Type mapping
 ------------
 All builtin types are mapped to their BSON equivalents. In addition, the following type mappings are used:

--- a/src/main/php/com/mongodb/Database.class.php
+++ b/src/main/php/com/mongodb/Database.class.php
@@ -26,7 +26,7 @@ class Database {
    * @return [:var][]
    * @throws com.mongodb.Error
    */
-  public function collections($session) {
+  public function collections($session= null) {
     $result= $this->proto->read($session, [
       'listCollections' => (object)[],
       '$db'             => $this->name

--- a/src/main/php/com/mongodb/Database.class.php
+++ b/src/main/php/com/mongodb/Database.class.php
@@ -22,11 +22,12 @@ class Database {
   /**
    * Returns a list of database information objects
    *
+   * @param  ?com.mongodb.Session $session
    * @return [:var][]
    * @throws com.mongodb.Error
    */
-  public function collections() {
-    $result= $this->proto->read([
+  public function collections($session) {
+    $result= $this->proto->read($session, [
       'listCollections' => (object)[],
       '$db'             => $this->name
     ]);

--- a/src/main/php/com/mongodb/MongoConnection.class.php
+++ b/src/main/php/com/mongodb/MongoConnection.class.php
@@ -38,6 +38,10 @@ class MongoConnection implements Value {
    */
   public function session($uuid= null) {
     $this->proto->connect();
+
+    // From the spec: "Drivers SHOULD generate session IDs locally if possible
+    // instead of running the startSession command, since running the command
+    // requires a network round trip".
     return new Session($this->proto, $uuid ?? UUID::randomUUID());
   }
 

--- a/src/main/php/com/mongodb/Session.class.php
+++ b/src/main/php/com/mongodb/Session.class.php
@@ -9,6 +9,7 @@ use util\UUID;
  *
  * @see   https://docs.mongodb.com/manual/reference/server-sessions/
  * @see   https://docs.mongodb.com/manual/core/read-isolation-consistency-recency/#std-label-sessions
+ * @see   https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.rst
  */
 class Session implements Closeable {
   private $proto, $id;

--- a/src/main/php/com/mongodb/Session.class.php
+++ b/src/main/php/com/mongodb/Session.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb;
 
 use com\mongodb\io\Protocol;
-use lang\Closeable;
+use lang\{Closeable, IllegalStateException};
 use util\UUID;
 
 /**
@@ -31,6 +31,19 @@ class Session implements Closeable {
 
   /** Returns whether this session was closed */
   public function closed(): bool { return $this->closed; }
+
+  /**
+   * Returns fields to be sent along with the command
+   *
+   * @param  com.mongodb.io.Protocol
+   * @return [:var]
+   * @throws lang.IllegalStateException
+   */
+  public function send($proto) {
+    if ($proto === $this->proto) return ['lsid' => ['id' => $this->id]];
+
+    throw new IllegalStateException('Session was created by a different client');
+  }
 
   /** @return void */
   public function close() {

--- a/src/main/php/com/mongodb/Session.class.php
+++ b/src/main/php/com/mongodb/Session.class.php
@@ -38,7 +38,7 @@ class Session implements Closeable {
 
     // Fire and forget: If the user has no session that match, the endSessions call has
     // no effect, see https://docs.mongodb.com/manual/reference/command/endSessions/
-    $this->proto->read([
+    $this->proto->read($this, [
       'endSessions' => [['id' => $this->id]],
       '$db'         => 'admin'
     ]);

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -187,7 +187,7 @@ class Protocol {
       );
     }
 
-    $session && $sections+= ['lsid' => ['id' => $session->id()]];
+    $session && $sections+= $session->send($this);
     return $selected->message($sections, $this->readPreference);
   }
 
@@ -200,7 +200,7 @@ class Protocol {
    * @throws com.mongodb.Error
    */
   public function write($session, $sections) {
-    $session && $sections+= ['lsid' => ['id' => $session->id()]];
+    $session && $sections+= $session->send($this);
     return $this->select([$this->nodes['primary']], 'writing')->message($sections, $this->readPreference);
   }
 

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -164,6 +164,7 @@ class Protocol {
    * @throws com.mongodb.Error
    */
   public function read($session, $sections) {
+    $session && $sections+= $session->send($this);
     $rp= $this->readPreference['mode'];
 
     if ('primary' === $rp) {
@@ -187,7 +188,6 @@ class Protocol {
       );
     }
 
-    $session && $sections+= $session->send($this);
     return $selected->message($sections, $this->readPreference);
   }
 

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -158,11 +158,12 @@ class Protocol {
    *
    * @see    https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#read-preference
    * @see    https://docs.mongodb.com/manual/core/read-preference-mechanics/
+   * @param  ?com.mongodb.Session $session
    * @param  [:var] $sections
    * @return var
    * @throws com.mongodb.Error
    */
-  public function read($sections) {
+  public function read($session, $sections) {
     $rp= $this->readPreference['mode'];
 
     if ('primary' === $rp) {
@@ -192,11 +193,12 @@ class Protocol {
   /**
    * Perform a write operation
    *
+   * @param  ?com.mongodb.Session $session
    * @param  [:var] $sections
    * @return var
    * @throws com.mongodb.Error
    */
-  public function write($sections) {
+  public function write($session, $sections) {
     return $this->select([$this->nodes['primary']], 'writing')->message($sections, $this->readPreference);
   }
 

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -187,6 +187,7 @@ class Protocol {
       );
     }
 
+    $session && $sections+= ['lsid' => ['id' => $session->id()]];
     return $selected->message($sections, $this->readPreference);
   }
 
@@ -199,6 +200,7 @@ class Protocol {
    * @throws com.mongodb.Error
    */
   public function write($session, $sections) {
+    $session && $sections+= ['lsid' => ['id' => $session->id()]];
     return $this->select([$this->nodes['primary']], 'writing')->message($sections, $this->readPreference);
   }
 

--- a/src/main/php/com/mongodb/result/Cursor.class.php
+++ b/src/main/php/com/mongodb/result/Cursor.class.php
@@ -15,7 +15,7 @@ class Cursor implements Value, IteratorAggregate {
    * @param  ?com.mongodb.Session $session
    * @param  [:var] $current
    */
-  public function __construct($proto, $session, $current= []) { 
+  public function __construct($proto, $session, $current) {
     $this->proto= $proto;
     $this->session= $session;
     $this->current= $current;

--- a/src/test/php/com/mongodb/unittest/CollectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionTest.class.php
@@ -20,8 +20,8 @@ class CollectionTest {
       'returning' => function($response) { $this->responses[]= $response; return $this; },
       'connect'   => function() { },
       'close'     => function() { /** NOOP */ },
-      'read'      => function($sections) { return ['body' => array_shift($this->responses)]; },
-      'write'     => function($sections) { return ['body' => array_shift($this->responses)]; },
+      'read'      => function($session, $sections) { return ['body' => array_shift($this->responses)]; },
+      'write'     => function($session, $sections) { return ['body' => array_shift($this->responses)]; },
     ]);
   }
 

--- a/src/test/php/com/mongodb/unittest/CollectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionTest.class.php
@@ -32,7 +32,6 @@ class CollectionTest {
    * @return com.mongodb.Collection
    */
   private function newFixture($response) {
-    $this->protocol->connect();
     return new Collection($this->protocol->returning($response), 'testing', 'tests');
   }
 

--- a/src/test/php/com/mongodb/unittest/result/CursorTest.class.php
+++ b/src/test/php/com/mongodb/unittest/result/CursorTest.class.php
@@ -15,7 +15,7 @@ class CursorTest {
 
   #[Test]
   public function can_create() {
-    new Cursor($this->proto, [
+    new Cursor($this->proto, null, [
       'firstBatch' => [],
       'id'         => new Int64(0),
       'ns'         => 'test.collection'
@@ -24,7 +24,7 @@ class CursorTest {
 
   #[Test]
   public function namespace() {
-    $fixture= new Cursor($this->proto, [
+    $fixture= new Cursor($this->proto, null, [
       'firstBatch' => [],
       'id'         => new Int64(0),
       'ns'         => 'test.collection'
@@ -35,7 +35,7 @@ class CursorTest {
   #[Test]
   public function documents() {
     $documents= [['_id' => 'one', 'qty'  => 1000], ['_id' => 'two', 'qty'  => 6100]];
-    $fixture= new Cursor($this->proto, [
+    $fixture= new Cursor($this->proto, null, [
       'firstBatch' => $documents,
       'id'         => new Int64(0),
       'ns'         => 'test.collection'
@@ -50,7 +50,7 @@ class CursorTest {
   #[Test]
   public function first_document() {
     $documents= [['_id' => 'one', 'qty'  => 1000]];
-    $fixture= new Cursor($this->proto, [
+    $fixture= new Cursor($this->proto, null, [
       'firstBatch' => $documents,
       'id'         => new Int64(0),
       'ns'         => 'test.collection'
@@ -62,7 +62,7 @@ class CursorTest {
   #[Test]
   public function first_when_not_found() {
     $documents= [];
-    $fixture= new Cursor($this->proto, [
+    $fixture= new Cursor($this->proto, null, [
       'firstBatch' => [],
       'id'         => new Int64(0),
       'ns'         => 'test.collection'


### PR DESCRIPTION
Using a causally consistent session, an application can read its own writes and is guaranteed monotonic reads, even when reading from replica set secondaries.

```php
use com\mongodb\{MongoConnection, ObjectId};
use util\cmd\Console;

$c= new MongoConnection('mongodb+srv://server.example.com?readPreference=secondary');
$session= $c->session();

$id= new ObjectId('...');

// Will write to primary
$collection= $c->collection('test.products');
$collection->update($id, ['$set' => ['qty' => 1]], $session);

// Will read the updated document
$updated= $collection->find($id, $session);

$session->close();
```
