### PR TITLE
Implement multi-document transactions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ MongoDB for XP Framework ChangeLog
 
 ## 0.9.1 / 2022-03-19
 
+* Fixed operation errors causing reconnection - @thekid
 * Normalized databases enumeration between MongoDB versions - @thekid
 * Fixed `com.mongodb.MongoConnection::databases()` - @thekid
 * Fixed `com.mongodb.Database::collections()` - @thekid

--- a/src/main/php/com/mongodb/Error.class.php
+++ b/src/main/php/com/mongodb/Error.class.php
@@ -1,13 +1,13 @@
 <?php namespace com\mongodb;
 
-use peer\ProtocolException;
+use lang\XPException;
 
 /**
  * MongoDB error
  *
  * @see   https://raw.githubusercontent.com/mongodb/mongo/master/src/mongo/base/error_codes.yml
  */
-class Error extends ProtocolException {
+class Error extends XPException {
   private $kind;
   
   /**

--- a/src/main/php/com/mongodb/Session.class.php
+++ b/src/main/php/com/mongodb/Session.class.php
@@ -1,8 +1,8 @@
 <?php namespace com\mongodb;
 
 use com\mongodb\io\Protocol;
-use lang\{Closeable, IllegalStateException};
-use util\UUID;
+use lang\{Closeable, IllegalStateException, Value, Throwable};
+use util\{UUID, Objects};
 
 /**
  * A client session
@@ -11,9 +11,10 @@ use util\UUID;
  * @see   https://docs.mongodb.com/manual/core/read-isolation-consistency-recency/#std-label-sessions
  * @see   https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.rst
  */
-class Session implements Closeable {
+class Session implements Value, Closeable {
   private $proto, $id;
   private $closed= false;
+  private $transaction= ['n' => 0];
 
   /**
    * Creates a new session
@@ -33,6 +34,68 @@ class Session implements Closeable {
   public function closed(): bool { return $this->closed; }
 
   /**
+   * Starts a multi-document transaction associated with the session. At any
+   * given time, you can have at most one open transaction for a session.
+   *
+   * @return self
+   * @throws lang.IllegalStateException if a transaction has already been started
+   */
+  public function transaction(): self {
+    if (isset($this->transaction['context'])) {
+      throw new IllegalStateException('Cannot start more than one transaction on a session');
+    }
+
+    $this->transaction['context']= [
+      'txnNumber'        => new Int64(++$this->transaction['n']),
+      'autocommit'       => false,
+      'startTransaction' => true,
+    ];
+    return $this;
+  }
+
+  /**
+   * Commits a transaction
+   *
+   * @return void
+   * @throws lang.IllegalStateException if no transaction is active
+   * @throws com.mongodb.Error
+   */
+  public function commit() {
+    if (!isset($this->transaction['context'])) {
+      throw new IllegalStateException('No active transaction');
+    }
+
+    try {
+      if (!isset($this->transaction['context']['startTransaction'])) {
+        $this->proto->write($this, ['commitTransaction' => 1, '$db' => 'admin'] + $this->transaction['context']);
+      }
+    } finally {
+      unset($this->transaction['context']);
+    }
+  }
+
+  /**
+   * Aborts a transaction
+   *
+   * @return void
+   * @throws lang.IllegalStateException if no transaction is active
+   * @throws com.mongodb.Error
+   */
+  public function abort() {
+    if (!isset($this->transaction['context'])) {
+      throw new IllegalStateException('No active transaction');
+    }
+
+    try {
+      if (!isset($this->transaction['context']['startTransaction'])) {
+        $this->proto->write($this, ['abortTransaction' => 1, '$db' => 'admin'] + $this->transaction['context']);
+      }
+    } finally {
+      unset($this->transaction['context']);
+    }
+  }
+
+  /**
    * Returns fields to be sent along with the command
    *
    * @param  com.mongodb.io.Protocol
@@ -40,22 +103,65 @@ class Session implements Closeable {
    * @throws lang.IllegalStateException
    */
   public function send($proto) {
-    if ($proto === $this->proto) return ['lsid' => ['id' => $this->id]];
+    if ($proto !== $this->proto) {
+      throw new IllegalStateException('Session was created by a different client');
+    }
 
-    throw new IllegalStateException('Session was created by a different client');
+    // When constructing the first command within a transaction, drivers MUST
+    // add the lsid, txnNumber, startTransaction, and autocommit fields. When 
+    // constructing any other command within a transaction, drivers MUST add
+    // the lsid, txnNumber, and autocommit fields.
+    $fields= ['lsid' => ['id' => $this->id]];
+    if (isset($this->transaction['context'])) {
+      $fields+= $this->transaction['context'];
+      unset($this->transaction['context']['startTransaction']);
+    }
+    return $fields;
   }
 
   /** @return void */
   public function close() {
     if ($this->closed) return;
 
+    // Should there be an active running transaction, abort it.
+    if (isset($this->transaction['context'])) {
+      try {
+        $this->proto->write($this, ['abortTransaction' => 1, '$db' => 'admin'] + $this->transaction['context']);
+      } catch (Throwable $ignored) {
+        // NOOP
+      }
+      unset($this->transaction['context']);
+    }
+
     // Fire and forget: If the user has no session that match, the endSessions call has
     // no effect, see https://docs.mongodb.com/manual/reference/command/endSessions/
-    $this->proto->read($this, [
-      'endSessions' => [['id' => $this->id]],
-      '$db'         => 'admin'
-    ]);
+    try {
+      $this->proto->write($this, ['endSessions' => [['id' => $this->id]], '$db' => 'admin']);
+    } catch (Throwable $ignored) {
+      // NOOP
+    }
     $this->closed= true;
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return 'S'.$this->id->hashCode();
+  }
+
+  /** @return string */
+  public function toString() {
+    $context= isset($this->transaction['context']) ? ', transaction: '.Objects::stringOf($this->transaction['context']) : '';
+    return nameof($this).'(id: '.$this->id->hashCode().$context.')';
+  }
+
+  /**
+   * Comparison
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? $this->id->compareTo($value->id) : 1;
   }
 
   /** @return void */

--- a/src/main/php/com/mongodb/Session.class.php
+++ b/src/main/php/com/mongodb/Session.class.php
@@ -10,6 +10,7 @@ use util\{UUID, Objects};
  * @see   https://docs.mongodb.com/manual/reference/server-sessions/
  * @see   https://docs.mongodb.com/manual/core/read-isolation-consistency-recency/#std-label-sessions
  * @see   https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.rst
+ * @test  com.mongodb.unittest.SessionsTest
  */
 class Session implements Value, Closeable {
   private $proto, $id;

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -7,7 +7,8 @@ use peer\{ConnectException, Socket, SocketException};
 /**
  * MongoDB Wire Protocol 
  *
- * @see https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/
+ * @see   https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/
+ * @test  com.mongodb.unittest.ReplicaSetTest
  */
 class Protocol {
   private $options, $conn, $auth;

--- a/src/test/php/com/mongodb/unittest/ReplicaSetTest.class.php
+++ b/src/test/php/com/mongodb/unittest/ReplicaSetTest.class.php
@@ -7,123 +7,18 @@ use unittest\{Assert, Values, Test};
 use util\{Date, UUID};
 
 class ReplicaSetTest {
-  const PRIMARY    = 'shard2.test:27017';
-  const SECONDARY1 = 'shard1.test:27017';
-  const SECONDARY2 = 'shard0.test:27017';
-  const SESSION    = '6ce334fc-4ce5-4d0c-be6a-1e34feebbad4';
-
-  /**
-   * Connect to a given replica set definition
-   *
-   * @param  [:var[]] $definition
-   * @param  string $readPreference
-   * @return com.mongodb.io.Protocol
-   */
-  private function connect($definition, $readPreference= 'primary') {
-    $conn= [];
-    foreach ($definition as $node => $replies) {
-      $conn[]= new TestingConnection($node, $replies);
-    }
-
-    return (new Protocol($conn, ['params' => ['readPreference' => $readPreference]]))->connect();
-  }
-
-  /**
-   * Returns map of addresses to server kinds
-   * 
-   * @param  com.mongodb.io.Protocol $proto
-   * @return [:?string]
-   */
-  private function connected($proto) {
-    return array_map(
-      function($conn) { return $conn->connected() ? $conn->server['$kind'] : null; },
-      $proto->connections()
-    );
-  }
-
-  /**
-   * Creates a hello reply
-   *
-   * @param  string $node
-   * @return [:var]
-   */
-  private function hello($node) {
-    return [
-      'responseFlags'   => 8,
-      'cursorID'        => 0,
-      'startingFrom'    => 0,
-      'numberReturned'  => 1,
-      'documents'       => [[
-        'topologyVersion'              => ['processId' => new ObjectId('6235b5ddda38998abb76bed3'), new Int64(6)],
-        'hosts'                        => [self::PRIMARY, self::SECONDARY1, self::SECONDARY2],
-        'setName'                      => 'atlas-test-shard-0',
-        'setVersion'                   => 8,
-        'isWritablePrimary'            => self::PRIMARY === $node,
-        'secondary'                    => self::PRIMARY !== $node,
-        'primary'                      => self::PRIMARY,
-        'tags'                         => [
-          'provider'     => 'AWS',
-          'region'       => 'EU_CENTRAL_1',
-          'nodeType'     => 'ELECTABLE',
-          'workloadType' => 'OPERATIONAL'
-        ],
-        'me'                           => $node,
-        'electionId'                   => new ObjectId('7fffffff0000000000000136'),
-        'lastWrite'                    => [
-          'opTime'            => ['ts' => new Timestamp(1647687293, 41), 't' => new Int64(310)],
-          'lastWriteDate'     => new Date('2022-03-19 10:54:53+0000'),
-          'majorityOpTime'    => ['ts' => new Timestamp(1647687293, 41), 't' => new Int64(310)],
-          'majorityWriteDate' => new Date('2022-03-19 10:54:53+0000'),
-        ],
-        'maxBsonObjectSize'            => 16777216,
-        'maxMessageSizeBytes'          => 48000000,
-        'maxWriteBatchSize'            => 100000,
-        'localTime'                    => new Date('2022-03-19 10:54:53+0000'),
-        'logicalSessionTimeoutMinutes' => 30,
-        'connectionId'                 => 873,
-        'minWireVersion'               => 0,
-        'maxWireVersion'               => 13,
-        'readOnly'                     => self::PRIMARY !== $node,
-        'ok'                           => 1,
-      ]]
-    ];
-  }
-
-  /**
-   * Creates an OK reply
-   *
-   * @return [:var]
-   */
-  private function ok() {
-    return ['flags' => 0, 'body' => ['ok' => 1]];
-  }
-
-  /**
-   * Creates a count reply
-   *
-   * @param  int $n
-   * @return [:var]
-   */
-  private function count($n) {
-    return [
-      'flags' => 0,
-      'body'  => [
-        'cursor' => ['firstBatch' => [['n' => $n]], 'id' => new Int64(0), 'ns' => 'test.entries'],
-        'ok'     => 1,
-      ],
-    ];
-  }
+  use WireTesting;
 
   #[Test]
   public function connections_when_first_is_primary() {
     $fixture= $this->connect([
-      self::PRIMARY    => [$this->hello(self::PRIMARY)],
-      self::SECONDARY1 => [$this->hello(self::SECONDARY1)],
-      self::SECONDARY2 => [$this->hello(self::SECONDARY2)],
+      self::$PRIMARY    => [$this->hello(self::$PRIMARY)],
+      self::$SECONDARY1 => [$this->hello(self::$SECONDARY1)],
+      self::$SECONDARY2 => [$this->hello(self::$SECONDARY2)],
     ]);
 
     Assert::equals(
-      [self::PRIMARY => TestingConnection::RSPrimary, self::SECONDARY1 => null, self::SECONDARY2 => null],
+      [self::$PRIMARY => TestingConnection::RSPrimary, self::$SECONDARY1 => null, self::$SECONDARY2 => null],
       $this->connected($fixture)
     );
   }
@@ -131,13 +26,13 @@ class ReplicaSetTest {
   #[Test]
   public function connections_when_first_is_secondary() {
     $fixture= $this->connect([
-      self::SECONDARY1 => [$this->hello(self::SECONDARY1)],
-      self::SECONDARY2 => [$this->hello(self::SECONDARY2)],
-      self::PRIMARY    => [$this->hello(self::PRIMARY)],
+      self::$SECONDARY1 => [$this->hello(self::$SECONDARY1)],
+      self::$SECONDARY2 => [$this->hello(self::$SECONDARY2)],
+      self::$PRIMARY    => [$this->hello(self::$PRIMARY)],
     ]);
 
     Assert::equals(
-      [self::SECONDARY1 => TestingConnection::RSSecondary, self::SECONDARY2 => null, self::PRIMARY => null],
+      [self::$SECONDARY1 => TestingConnection::RSSecondary, self::$SECONDARY2 => null, self::$PRIMARY => null],
       $this->connected($fixture)
     );
   }
@@ -145,41 +40,41 @@ class ReplicaSetTest {
   #[Test]
   public function connects_to_primary_when_no_secondary_available() {
     $replicaSet= [
-      self::PRIMARY    => [$this->hello(self::PRIMARY), $this->ok()],
-      self::SECONDARY1 => [],
-      self::SECONDARY2 => [],
+      self::$PRIMARY    => [$this->hello(self::$PRIMARY), $this->ok()],
+      self::$SECONDARY1 => [],
+      self::$SECONDARY2 => [],
     ];
     $fixture= $this->connect($replicaSet, 'secondaryPreferred');
     $fixture->read(null, [/* anything */]);
 
     Assert::equals(
-      [self::PRIMARY => TestingConnection::RSPrimary, self::SECONDARY1 => null, self::SECONDARY2 => null],
+      [self::$PRIMARY => TestingConnection::RSPrimary, self::$SECONDARY1 => null, self::$SECONDARY2 => null],
       $this->connected($fixture)
     );
   }
 
   #[Test, Expect(class: NoSuitableCandidate::class, withMessage: '/No suitable candidate eligible for initial connect/')]
   public function throws_exception_if_none_of_the_nodes_are_reachable() {
-    $this->connect([self::PRIMARY => null, self::SECONDARY1 => null, self::SECONDARY2 => null]);
+    $this->connect([self::$PRIMARY => null, self::$SECONDARY1 => null, self::$SECONDARY2 => null]);
   }
 
   #[Test, Expect(class: NoSuitableCandidate::class, withMessage: '/No suitable candidate eligible for initial connect/')]
   public function throws_exception_if_none_of_the_nodes_respond() {
-    $this->connect([self::PRIMARY => [], self::SECONDARY1 => [], self::SECONDARY2 => []]);
+    $this->connect([self::$PRIMARY => [], self::$SECONDARY1 => [], self::$SECONDARY2 => []]);
   }
 
   #[Test, Values(['secondary', 'secondaryPreferred'])]
   public function reads_from_first_secondary_with($readPreference) {
     $replicaSet= [
-      self::PRIMARY    => [$this->hello(self::PRIMARY)],
-      self::SECONDARY1 => [$this->hello(self::SECONDARY1), $this->ok()],
-      self::SECONDARY2 => [$this->hello(self::SECONDARY2)],
+      self::$PRIMARY    => [$this->hello(self::$PRIMARY)],
+      self::$SECONDARY1 => [$this->hello(self::$SECONDARY1), $this->ok()],
+      self::$SECONDARY2 => [$this->hello(self::$SECONDARY2)],
     ];
     $fixture= $this->connect($replicaSet, $readPreference);
     $fixture->read(null, [/* anything */]);
 
     Assert::equals(
-      [self::PRIMARY => TestingConnection::RSPrimary, self::SECONDARY1 => TestingConnection::RSSecondary, self::SECONDARY2 => null],
+      [self::$PRIMARY => TestingConnection::RSPrimary, self::$SECONDARY1 => TestingConnection::RSSecondary, self::$SECONDARY2 => null],
       $this->connected($fixture)
     );
   }
@@ -187,15 +82,15 @@ class ReplicaSetTest {
   #[Test, Values(['secondary', 'secondaryPreferred'])]
   public function reads_from_first_available_secondary_with($readPreference) {
     $replicaSet= [
-      self::PRIMARY    => [$this->hello(self::PRIMARY)],
-      self::SECONDARY1 => [],
-      self::SECONDARY2 => [$this->hello(self::SECONDARY2), $this->ok()],
+      self::$PRIMARY    => [$this->hello(self::$PRIMARY)],
+      self::$SECONDARY1 => [],
+      self::$SECONDARY2 => [$this->hello(self::$SECONDARY2), $this->ok()],
     ];
     $fixture= $this->connect($replicaSet, $readPreference);
     $fixture->read(null, [/* anything */]);
 
     Assert::equals(
-      [self::PRIMARY => TestingConnection::RSPrimary, self::SECONDARY1 => null, self::SECONDARY2 => TestingConnection::RSSecondary],
+      [self::$PRIMARY => TestingConnection::RSPrimary, self::$SECONDARY1 => null, self::$SECONDARY2 => TestingConnection::RSSecondary],
       $this->connected($fixture)
     );
   }
@@ -203,15 +98,15 @@ class ReplicaSetTest {
   #[Test, Values(['secondary', 'secondaryPreferred'])]
   public function reads_from_another_secondary($readPreference) {
     $replicaSet= [
-      self::PRIMARY    => [$this->hello(self::PRIMARY)],
-      self::SECONDARY1 => [$this->hello(self::SECONDARY1)],
-      self::SECONDARY2 => [$this->hello(self::SECONDARY2), $this->ok()],
+      self::$PRIMARY    => [$this->hello(self::$PRIMARY)],
+      self::$SECONDARY1 => [$this->hello(self::$SECONDARY1)],
+      self::$SECONDARY2 => [$this->hello(self::$SECONDARY2), $this->ok()],
     ];
     $fixture= $this->connect($replicaSet, $readPreference);
     $fixture->read(null, [/* anything */]);
 
     Assert::equals(
-      [self::PRIMARY => TestingConnection::RSPrimary, self::SECONDARY1 => null, self::SECONDARY2 => TestingConnection::RSSecondary],
+      [self::$PRIMARY => TestingConnection::RSPrimary, self::$SECONDARY1 => null, self::$SECONDARY2 => TestingConnection::RSSecondary],
       $this->connected($fixture)
     );
   }
@@ -219,9 +114,9 @@ class ReplicaSetTest {
   #[Test, Values(map: ['primary' => 45, 'primaryPreferred' => 45, 'secondary' => 44, 'secondaryPreferred' => 44, 'nearest' => 45])]
   public function reading_with($readPreference, $result) {
     $replicaSet= [
-      self::PRIMARY     => [$this->hello(self::PRIMARY), $this->count(45)],
-      self::SECONDARY1  => [$this->hello(self::SECONDARY1), $this->count(44)],
-      self::SECONDARY2  => [$this->hello(self::SECONDARY1), $this->count(44)],
+      self::$PRIMARY     => [$this->hello(self::$PRIMARY), $this->count(45)],
+      self::$SECONDARY1  => [$this->hello(self::$SECONDARY1), $this->count(44)],
+      self::$SECONDARY2  => [$this->hello(self::$SECONDARY1), $this->count(44)],
     ];
     $response= $this->connect($replicaSet, $readPreference)->read(null, [
       'aggregate' => 'test.entries',
@@ -236,7 +131,7 @@ class ReplicaSetTest {
   #[Test]
   public function writing() {
     $replicaSet= [
-      self::PRIMARY     => [$this->hello(self::PRIMARY), [
+      self::$PRIMARY     => [$this->hello(self::$PRIMARY), [
         'flags' => 0,
         'body'  => [
           'n'          => 1,
@@ -245,7 +140,7 @@ class ReplicaSetTest {
           'ok'         => 1
         ]
       ]],
-      self::SECONDARY1  => [$this->hello(self::SECONDARY1), [
+      self::$SECONDARY1  => [$this->hello(self::$SECONDARY1), [
         'flags' => 0,
         'body'  => [
           'topologyVersion' => ['processId' => new ObjectId('6235b49ff525c94b4ecdd835'), 'counter' => new Int64(4)],
@@ -255,7 +150,7 @@ class ReplicaSetTest {
           'codeName'        => 'NotWritablePrimary',
         ]
       ]],
-      self::SECONDARY2  => [],
+      self::$SECONDARY2  => [],
     ];
     $response= $this->connect($replicaSet)->write(null, [
       'delete'    => 'test',
@@ -270,9 +165,9 @@ class ReplicaSetTest {
   #[Test, Expect(class: NoSuitableCandidate::class, withMessage: '/No suitable candidate eligible for reading with secondary/')]
   public function read_throws_if_no_secondaries_are_available() {
     $replicaSet= [
-      self::PRIMARY    => [$this->hello(self::PRIMARY)],
-      self::SECONDARY1 => [$this->hello(self::SECONDARY1)],
-      self::SECONDARY2 => [$this->hello(self::SECONDARY2)],
+      self::$PRIMARY    => [$this->hello(self::$PRIMARY)],
+      self::$SECONDARY1 => [$this->hello(self::$SECONDARY1)],
+      self::$SECONDARY2 => [$this->hello(self::$SECONDARY2)],
     ];
     $fixture= $this->connect($replicaSet, 'secondary');
     $fixture->read(null, [/* anything */]);
@@ -281,9 +176,9 @@ class ReplicaSetTest {
   #[Test, Expect(class: NoSuitableCandidate::class, withMessage: '/No suitable candidate eligible for writing/')]
   public function write_throws_if_no_primary_is_available() {
     $replicaSet= [
-      self::PRIMARY    => [$this->hello(self::PRIMARY)],
-      self::SECONDARY1 => [$this->hello(self::SECONDARY1)],
-      self::SECONDARY2 => [$this->hello(self::SECONDARY2)],
+      self::$PRIMARY    => [$this->hello(self::$PRIMARY)],
+      self::$SECONDARY1 => [$this->hello(self::$SECONDARY1)],
+      self::$SECONDARY2 => [$this->hello(self::$SECONDARY2)],
     ];
     $fixture= $this->connect($replicaSet, 'primary');
     $fixture->write(null, [/* anything */]);
@@ -292,9 +187,9 @@ class ReplicaSetTest {
   #[Test]
   public function reconnects_when_checking_for_socket_with_ping_fails() {
     $replicaSet= [
-      self::PRIMARY    => [$this->hello(self::PRIMARY)],
-      self::SECONDARY1 => [$this->hello(self::SECONDARY1), $this->count(44), null, $this->hello(self::SECONDARY1), $this->count(45)],
-      self::SECONDARY2 => [],
+      self::$PRIMARY    => [$this->hello(self::$PRIMARY)],
+      self::$SECONDARY1 => [$this->hello(self::$SECONDARY1), $this->count(44), null, $this->hello(self::$SECONDARY1), $this->count(45)],
+      self::$SECONDARY2 => [],
     ];
     $fixture= $this->connect($replicaSet, 'secondary');
     $fixture->socketCheckInterval= 0;
@@ -322,7 +217,7 @@ class ReplicaSetTest {
   #[Test]
   public function does_not_disconnect_for_operation_errors() {
     $replicaSet= [
-      self::PRIMARY    => [$this->hello(self::PRIMARY), [
+      self::$PRIMARY    => [$this->hello(self::$PRIMARY), [
         'flags' => 0,
         'body'  => [
           'topologyVersion' => ['processId' => new ObjectId('6235b49ff525c94b4ecdd835'), 'counter' => new Int64(4)],
@@ -332,8 +227,8 @@ class ReplicaSetTest {
           'codeName'        => 'AtlasError',
         ]
       ]],
-      self::SECONDARY1 => [$this->hello(self::SECONDARY1)],
-      self::SECONDARY2 => [$this->hello(self::SECONDARY2)],
+      self::$SECONDARY1 => [$this->hello(self::$SECONDARY1)],
+      self::$SECONDARY2 => [$this->hello(self::$SECONDARY2)],
     ];
     $fixture= $this->connect($replicaSet, 'primary');
 
@@ -341,55 +236,8 @@ class ReplicaSetTest {
       $fixture->read(null, [/* anything */]);
     });
     Assert::equals(
-      [self::PRIMARY => TestingConnection::RSPrimary, self::SECONDARY1 => null, self::SECONDARY2 => null],
+      [self::$PRIMARY => TestingConnection::RSPrimary, self::$SECONDARY1 => null, self::$SECONDARY2 => null],
       $this->connected($fixture)
     );
-  }
-
-  #[Test]
-  public function session_id_is_sent_along() {
-    $replicaSet= [
-      self::PRIMARY    => [$this->hello(self::PRIMARY), $this->count(45), $this->ok()],
-      self::SECONDARY1 => [],
-      self::SECONDARY2 => [],
-    ];
-    $fixture= $this->connect($replicaSet, 'primary');
-    $count= ['count' => 'entries', '$db' => 'test'];
-
-    $id= new UUID(self::SESSION);
-    $session= new Session($fixture, $id);
-    $fixture->read($session, $count);
-    $session->close();
-
-    $conn= $fixture->connections()[self::PRIMARY];
-    $context= ['lsid' => ['id' => $id], '$readPreference' => ['mode' => 'primary']];
-
-    Assert::equals($count + $context, $conn->command(-2));
-    Assert::equals(['endSessions' => [['id' => $id]], '$db' => 'admin'] + $context, $conn->command(-1));
-  }
-
-  #[Test]
-  public function transaction_context_is_sent_along() {
-    $replicaSet= [
-      self::PRIMARY    => [$this->hello(self::PRIMARY), $this->ok(), $this->ok(), $this->ok()],
-      self::SECONDARY1 => [],
-      self::SECONDARY2 => [],
-    ];
-    $fixture= $this->connect($replicaSet, 'primary');
-    $update= ['update' => 'entries', 'updates' => [], '$db' => 'test'];
-
-    $id= new UUID(self::SESSION);
-    $transaction= (new Session($fixture, $id))->transaction();
-    $fixture->write($transaction, $update);
-    $fixture->write($transaction, $update);
-    $transaction->commit();
-
-    $conn= $fixture->connections()[self::PRIMARY];
-    $context= ['lsid' => ['id' => $id], '$readPreference' => ['mode' => 'primary']];
-    $txn= ['txnNumber' => new Int64(1), 'autocommit' => false];
-
-    Assert::equals($txn + ['startTransaction' => true] + $update + $context, $conn->command(-3));
-    Assert::equals($txn + $update + $context, $conn->command(-2));
-    Assert::equals($txn + ['commitTransaction' => 1, '$db' => 'admin'] + $context, $conn->command(-1));
   }
 }

--- a/src/test/php/com/mongodb/unittest/ReplicaSetTest.class.php
+++ b/src/test/php/com/mongodb/unittest/ReplicaSetTest.class.php
@@ -9,6 +9,19 @@ use util\{Date, UUID};
 class ReplicaSetTest {
   use WireTesting;
 
+  /**
+   * Returns map of addresses to server kinds
+   * 
+   * @param  com.mongodb.io.Protocol $proto
+   * @return [:?string]
+   */
+  private function connected($proto) {
+    return array_map(
+      function($conn) { return $conn->connected() ? $conn->server['$kind'] : null; },
+      $proto->connections()
+    );
+  }
+
   #[Test]
   public function connections_when_first_is_primary() {
     $fixture= $this->connect([

--- a/src/test/php/com/mongodb/unittest/SessionsTest.class.php
+++ b/src/test/php/com/mongodb/unittest/SessionsTest.class.php
@@ -1,58 +1,110 @@
 <?php namespace com\mongodb\unittest;
 
 use com\mongodb\{Session, Int64};
-use unittest\{Assert, Test};
+use unittest\{Assert, Before, Test};
 use util\UUID;
 
 class SessionsTest {
-  const SESSION = '5f375bfe-af78-4af8-bb03-5d441a66a5fb';
-
   use WireTesting;
+
+  private $id;
+
+  /**
+   * Runs an execute function inside a session
+   * 
+   * @param  [:var] $replies
+   * @param  function(com.mongodb.io.Protocol, com.mongodb.Session): void $execute
+   * @return com.mongodb.io.Protocol
+   */
+  private function session($replies, $execute) {
+    $proto= $this->connect($replies, 'primary');
+
+    $session= new Session($proto, $this->id);
+    $execute($proto, $session);
+    $session->close();
+
+    return $proto;
+  }
+
+  /**
+   * Runs a command twice in a transaction
+   * 
+   * @param  [:var] $replies
+   * @param  [:var] $command
+   * @param  ?string $options
+   * @return com.mongodb.io.Protocol
+   */
+  private function transaction($replies, $command, $options= null) {
+    return $this->session($replies, function($proto, $session) use($command, $options) {
+      $transaction= $session->transaction($options);
+      $proto->write($transaction, $command);
+      $proto->write($transaction, $command);
+      $transaction->commit();
+    });
+  }
+
+  #[Before]
+  public function id() {
+    $this->id= new UUID('5f375bfe-af78-4af8-bb03-5d441a66a5fb');
+  }
 
   #[Test]
   public function session_id_is_sent_along() {
-    $replicaSet= [
-      self::$PRIMARY    => [$this->hello(self::$PRIMARY), $this->count(45), $this->ok()],
-      self::$SECONDARY1 => [],
-      self::$SECONDARY2 => [],
-    ];
-    $fixture= $this->connect($replicaSet, 'primary');
+    $replies= [self::$PRIMARY => [$this->hello(self::$PRIMARY), $this->count(45), $this->ok()]];
     $count= ['count' => 'entries', '$db' => 'test'];
-
-    $id= new UUID(self::SESSION);
-    $session= new Session($fixture, $id);
-    $fixture->read($session, $count);
-    $session->close();
+    $fixture= $this->session($replies, function($proto, $session) use($count) {
+      $proto->read($session, $count);
+    });
 
     $conn= $fixture->connections()[self::$PRIMARY];
-    $context= ['lsid' => ['id' => $id], '$readPreference' => ['mode' => 'primary']];
+    $context= ['lsid' => ['id' => $this->id], '$readPreference' => ['mode' => 'primary']];
 
     Assert::equals($count + $context, $conn->command(-2));
-    Assert::equals(['endSessions' => [['id' => $id]], '$db' => 'admin'] + $context, $conn->command(-1));
+    Assert::equals(['endSessions' => [['id' => $this->id]], '$db' => 'admin'] + $context, $conn->command(-1));
   }
 
   #[Test]
   public function transaction_context_is_sent_along() {
-    $replicaSet= [
-      self::$PRIMARY    => [$this->hello(self::$PRIMARY), $this->ok(), $this->ok(), $this->ok(), $this->ok()],
-      self::$SECONDARY1 => [],
-      self::$SECONDARY2 => [],
-    ];
-    $fixture= $this->connect($replicaSet, 'primary');
+    $replies= [self::$PRIMARY => [$this->hello(self::$PRIMARY), $this->ok(), $this->ok(), $this->ok(), $this->ok()]];
     $update= ['update' => 'entries', 'updates' => [], '$db' => 'test'];
-
-    $id= new UUID(self::SESSION);
-    $transaction= (new Session($fixture, $id))->transaction();
-    $fixture->write($transaction, $update);
-    $fixture->write($transaction, $update);
-    $transaction->commit();
+    $fixture= $this->transaction($replies, $update);
 
     $conn= $fixture->connections()[self::$PRIMARY];
-    $context= ['lsid' => ['id' => $id], '$readPreference' => ['mode' => 'primary']];
+    $context= ['lsid' => ['id' => $this->id], '$readPreference' => ['mode' => 'primary']];
     $txn= ['txnNumber' => new Int64(1), 'autocommit' => false];
 
-    Assert::equals($txn + ['startTransaction' => true] + $update + $context, $conn->command(-3));
-    Assert::equals($txn + $update + $context, $conn->command(-2));
-    Assert::equals($txn + ['commitTransaction' => 1, '$db' => 'admin'] + $context, $conn->command(-1));
+    Assert::equals($txn + ['startTransaction' => true] + $update + $context, $conn->command(-4));
+    Assert::equals($txn + $update + $context, $conn->command(-3));
+    Assert::equals($txn + ['commitTransaction' => 1, '$db' => 'admin'] + $context, $conn->command(-2));
+  }
+
+  #[Test]
+  public function readPreference_passed_to_transaction() {
+    $replies= [self::$PRIMARY => [$this->hello(self::$PRIMARY), $this->ok(), $this->ok(), $this->ok(), $this->ok()]];
+    $update= ['update' => 'entries', 'updates' => [], '$db' => 'test'];
+    $fixture= $this->transaction($replies, $update, 'readPreference=primaryPreferred');
+
+    $conn= $fixture->connections()[self::$PRIMARY];
+    $context= ['lsid' => ['id' => $this->id], '$readPreference' => ['mode' => 'primaryPreferred']];
+    $txn= ['txnNumber' => new Int64(1), 'autocommit' => false];
+
+    Assert::equals($txn + ['startTransaction' => true] + $update + $context, $conn->command(-4));
+    Assert::equals($txn + $update + $context, $conn->command(-3));
+    Assert::equals($txn + ['commitTransaction' => 1, '$db' => 'admin'] + $context, $conn->command(-2));
+  }
+
+  #[Test]
+  public function timeoutMS_passed_to_transaction() {
+    $replies= [self::$PRIMARY => [$this->hello(self::$PRIMARY), $this->ok(), $this->ok(), $this->ok(), $this->ok()]];
+    $update= ['update' => 'entries', 'updates' => [], '$db' => 'test'];
+    $fixture= $this->transaction($replies, $update, 'timeoutMS=5000');
+
+    $conn= $fixture->connections()[self::$PRIMARY];
+    $context= ['lsid' => ['id' => $this->id], '$readPreference' => ['mode' => 'primary']];
+    $txn= ['txnNumber' => new Int64(1), 'autocommit' => false];
+
+    Assert::equals($txn + ['startTransaction' => true] + $update + $context, $conn->command(-4));
+    Assert::equals($txn + $update + $context, $conn->command(-3));
+    Assert::equals($txn + ['commitTransaction' => 1, 'maxTimeMS' => new Int64(5000), '$db' => 'admin'] + $context, $conn->command(-2));
   }
 }

--- a/src/test/php/com/mongodb/unittest/SessionsTest.class.php
+++ b/src/test/php/com/mongodb/unittest/SessionsTest.class.php
@@ -1,0 +1,58 @@
+<?php namespace com\mongodb\unittest;
+
+use com\mongodb\{Session, Int64};
+use unittest\{Assert, Test};
+use util\UUID;
+
+class SessionsTest {
+  const SESSION = '5f375bfe-af78-4af8-bb03-5d441a66a5fb';
+
+  use WireTesting;
+
+  #[Test]
+  public function session_id_is_sent_along() {
+    $replicaSet= [
+      self::$PRIMARY    => [$this->hello(self::$PRIMARY), $this->count(45), $this->ok()],
+      self::$SECONDARY1 => [],
+      self::$SECONDARY2 => [],
+    ];
+    $fixture= $this->connect($replicaSet, 'primary');
+    $count= ['count' => 'entries', '$db' => 'test'];
+
+    $id= new UUID(self::SESSION);
+    $session= new Session($fixture, $id);
+    $fixture->read($session, $count);
+    $session->close();
+
+    $conn= $fixture->connections()[self::$PRIMARY];
+    $context= ['lsid' => ['id' => $id], '$readPreference' => ['mode' => 'primary']];
+
+    Assert::equals($count + $context, $conn->command(-2));
+    Assert::equals(['endSessions' => [['id' => $id]], '$db' => 'admin'] + $context, $conn->command(-1));
+  }
+
+  #[Test]
+  public function transaction_context_is_sent_along() {
+    $replicaSet= [
+      self::$PRIMARY    => [$this->hello(self::$PRIMARY), $this->ok(), $this->ok(), $this->ok(), $this->ok()],
+      self::$SECONDARY1 => [],
+      self::$SECONDARY2 => [],
+    ];
+    $fixture= $this->connect($replicaSet, 'primary');
+    $update= ['update' => 'entries', 'updates' => [], '$db' => 'test'];
+
+    $id= new UUID(self::SESSION);
+    $transaction= (new Session($fixture, $id))->transaction();
+    $fixture->write($transaction, $update);
+    $fixture->write($transaction, $update);
+    $transaction->commit();
+
+    $conn= $fixture->connections()[self::$PRIMARY];
+    $context= ['lsid' => ['id' => $id], '$readPreference' => ['mode' => 'primary']];
+    $txn= ['txnNumber' => new Int64(1), 'autocommit' => false];
+
+    Assert::equals($txn + ['startTransaction' => true] + $update + $context, $conn->command(-3));
+    Assert::equals($txn + $update + $context, $conn->command(-2));
+    Assert::equals($txn + ['commitTransaction' => 1, '$db' => 'admin'] + $context, $conn->command(-1));
+  }
+}

--- a/src/test/php/com/mongodb/unittest/SessionsTest.class.php
+++ b/src/test/php/com/mongodb/unittest/SessionsTest.class.php
@@ -80,31 +80,23 @@ class SessionsTest {
 
   #[Test]
   public function readPreference_passed_to_transaction() {
-    $replies= [self::$PRIMARY => [$this->hello(self::$PRIMARY), $this->ok(), $this->ok(), $this->ok(), $this->ok()]];
-    $update= ['update' => 'entries', 'updates' => [], '$db' => 'test'];
-    $fixture= $this->transaction($replies, $update, 'readPreference=primaryPreferred');
+    $fixture= $this->transaction(
+      [self::$PRIMARY => [$this->hello(self::$PRIMARY), $this->ok(), $this->ok(), $this->ok(), $this->ok()]],
+      [/* anything */],
+      'readPreference=primaryPreferred'
+    );
 
-    $conn= $fixture->connections()[self::$PRIMARY];
-    $context= ['lsid' => ['id' => $this->id], '$readPreference' => ['mode' => 'primaryPreferred']];
-    $txn= ['txnNumber' => new Int64(1), 'autocommit' => false];
-
-    Assert::equals($txn + ['startTransaction' => true] + $update + $context, $conn->command(-4));
-    Assert::equals($txn + $update + $context, $conn->command(-3));
-    Assert::equals($txn + ['commitTransaction' => 1, '$db' => 'admin'] + $context, $conn->command(-2));
+    Assert::equals('primaryPreferred', $fixture->connections()[self::$PRIMARY]->command(-3)['$readPreference']['mode']);
   }
 
   #[Test]
   public function timeoutMS_passed_to_transaction() {
-    $replies= [self::$PRIMARY => [$this->hello(self::$PRIMARY), $this->ok(), $this->ok(), $this->ok(), $this->ok()]];
-    $update= ['update' => 'entries', 'updates' => [], '$db' => 'test'];
-    $fixture= $this->transaction($replies, $update, 'timeoutMS=5000');
+    $fixture= $this->transaction(
+      [self::$PRIMARY => [$this->hello(self::$PRIMARY), $this->ok(), $this->ok(), $this->ok(), $this->ok()]],
+      [/* anything */],
+      'timeoutMS=5000'
+    );
 
-    $conn= $fixture->connections()[self::$PRIMARY];
-    $context= ['lsid' => ['id' => $this->id], '$readPreference' => ['mode' => 'primary']];
-    $txn= ['txnNumber' => new Int64(1), 'autocommit' => false];
-
-    Assert::equals($txn + ['startTransaction' => true] + $update + $context, $conn->command(-4));
-    Assert::equals($txn + $update + $context, $conn->command(-3));
-    Assert::equals($txn + ['commitTransaction' => 1, 'maxTimeMS' => new Int64(5000), '$db' => 'admin'] + $context, $conn->command(-2));
+    Assert::equals(new Int64(5000), $fixture->connections()[self::$PRIMARY]->command(-2)['maxTimeMS']);
   }
 }

--- a/src/test/php/com/mongodb/unittest/SessionsTest.class.php
+++ b/src/test/php/com/mongodb/unittest/SessionsTest.class.php
@@ -76,6 +76,7 @@ class SessionsTest {
     Assert::equals($txn + ['startTransaction' => true] + $update + $context, $conn->command(-4));
     Assert::equals($txn + $update + $context, $conn->command(-3));
     Assert::equals($txn + ['commitTransaction' => 1, '$db' => 'admin'] + $context, $conn->command(-2));
+    Assert::equals(['endSessions' => [['id' => $this->id]], '$db' => 'admin'] + $context, $conn->command(-1));
   }
 
   #[Test]

--- a/src/test/php/com/mongodb/unittest/TestingConnection.class.php
+++ b/src/test/php/com/mongodb/unittest/TestingConnection.class.php
@@ -7,6 +7,7 @@ use util\Bytes;
 
 class TestingConnection extends Connection {
   private $replies;
+  private $sent= [];
 
   /**
    * Creates a new testing connection with specified replies.
@@ -29,6 +30,8 @@ class TestingConnection extends Connection {
    * @throws peer.ProtocolException
    */
   public function send($operation, $header, $sections) {
+    $this->sent[]= $sections;
+
     $reply= $this->replies ? array_shift($this->replies) : null;
     if (null === $reply) {
       throw new ProtocolException('Received EOF while reading');
@@ -45,5 +48,15 @@ class TestingConnection extends Connection {
       ],
       'operationTime' => new Timestamp(1647687293, 41),
     ];
+  }
+
+  /**
+   * Access the sent command history.
+   *
+   * @param  int $offset
+   * @return var[]
+   */
+  public function command($offset) {
+    return $this->sent[$offset < 0 ? sizeof($this->sent) + $offset : $offset] ?? null;
   }
 }

--- a/src/test/php/com/mongodb/unittest/WireTesting.class.php
+++ b/src/test/php/com/mongodb/unittest/WireTesting.class.php
@@ -1,0 +1,113 @@
+<?php namespace com\mongodb\unittest;
+
+use com\mongodb\io\Protocol;
+use com\mongodb\{Int64, ObjectId, Timestamp};
+use util\{Date, Bytes};
+
+trait WireTesting {
+  private static $PRIMARY    = 'shard2.test:27017';
+  private static $SECONDARY1 = 'shard1.test:27017';
+  private static $SECONDARY2 = 'shard0.test:27017';
+
+  /**
+   * Connect to a given replica set definition
+   *
+   * @param  [:var[]] $definition
+   * @param  string $readPreference
+   * @return com.mongodb.io.Protocol
+   */
+  private function connect($definition, $readPreference= 'primary') {
+    $conn= [];
+    foreach ($definition as $node => $replies) {
+      $conn[]= new TestingConnection($node, $replies);
+    }
+
+    return (new Protocol($conn, ['params' => ['readPreference' => $readPreference]]))->connect();
+  }
+
+  /**
+   * Returns map of addresses to server kinds
+   * 
+   * @param  com.mongodb.io.Protocol $proto
+   * @return [:?string]
+   */
+  private function connected($proto) {
+    return array_map(
+      function($conn) { return $conn->connected() ? $conn->server['$kind'] : null; },
+      $proto->connections()
+    );
+  }
+
+  /**
+   * Creates a hello reply
+   *
+   * @param  string $node
+   * @return [:var]
+   */
+  private function hello($node) {
+    return [
+      'responseFlags'   => 8,
+      'cursorID'        => 0,
+      'startingFrom'    => 0,
+      'numberReturned'  => 1,
+      'documents'       => [[
+        'topologyVersion'              => ['processId' => new ObjectId('6235b5ddda38998abb76bed3'), new Int64(6)],
+        'hosts'                        => [self::$PRIMARY, self::$SECONDARY1, self::$SECONDARY2],
+        'setName'                      => 'atlas-test-shard-0',
+        'setVersion'                   => 8,
+        'isWritablePrimary'            => self::$PRIMARY === $node,
+        'secondary'                    => self::$PRIMARY !== $node,
+        'primary'                      => self::$PRIMARY,
+        'tags'                         => [
+          'provider'     => 'AWS',
+          'region'       => 'EU_CENTRAL_1',
+          'nodeType'     => 'ELECTABLE',
+          'workloadType' => 'OPERATIONAL'
+        ],
+        'me'                           => $node,
+        'electionId'                   => new ObjectId('7fffffff0000000000000136'),
+        'lastWrite'                    => [
+          'opTime'            => ['ts' => new Timestamp(1647687293, 41), 't' => new Int64(310)],
+          'lastWriteDate'     => new Date('2022-03-19 10:54:53+0000'),
+          'majorityOpTime'    => ['ts' => new Timestamp(1647687293, 41), 't' => new Int64(310)],
+          'majorityWriteDate' => new Date('2022-03-19 10:54:53+0000'),
+        ],
+        'maxBsonObjectSize'            => 16777216,
+        'maxMessageSizeBytes'          => 48000000,
+        'maxWriteBatchSize'            => 100000,
+        'localTime'                    => new Date('2022-03-19 10:54:53+0000'),
+        'logicalSessionTimeoutMinutes' => 30,
+        'connectionId'                 => 873,
+        'minWireVersion'               => 0,
+        'maxWireVersion'               => 13,
+        'readOnly'                     => self::$PRIMARY !== $node,
+        'ok'                           => 1,
+      ]]
+    ];
+  }
+
+  /**
+   * Creates an OK reply
+   *
+   * @return [:var]
+   */
+  private function ok() {
+    return ['flags' => 0, 'body' => ['ok' => 1]];
+  }
+
+  /**
+   * Creates a count reply
+   *
+   * @param  int $n
+   * @return [:var]
+   */
+  private function count($n) {
+    return [
+      'flags' => 0,
+      'body'  => [
+        'cursor' => ['firstBatch' => [['n' => $n]], 'id' => new Int64(0), 'ns' => 'test.entries'],
+        'ok'     => 1,
+      ],
+    ];
+  }
+}

--- a/src/test/php/com/mongodb/unittest/WireTesting.class.php
+++ b/src/test/php/com/mongodb/unittest/WireTesting.class.php
@@ -26,19 +26,6 @@ trait WireTesting {
   }
 
   /**
-   * Returns map of addresses to server kinds
-   * 
-   * @param  com.mongodb.io.Protocol $proto
-   * @return [:?string]
-   */
-  private function connected($proto) {
-    return array_map(
-      function($conn) { return $conn->connected() ? $conn->server['$kind'] : null; },
-      $proto->connections()
-    );
-  }
-
-  /**
    * Creates a hello reply
    *
    * @param  string $node


### PR DESCRIPTION
Implements #12:

```php
use com\mongodb\MongoConnection;

$c= new MongoConnection('mongodb+srv://server.example.com');

$transaction= $c->session()->transaction();

// Update two documents
$collection->update($id1, ['$inc' => ['qty' => -1]], $transaction);
$collection->update($id2, ['$inc' => ['qty' => 1]], $transaction);

// Reads changed values
Console::writeLine('Inside: ', [...$collection->find(['qty' => ['$exists' => true]], $transaction)]);

$transaction->commit();  // or $transaction->abort();

// Reads committed values, original values if aborted
Console::writeLine('Outside: ', [...$collection->find(['qty' => ['$exists' => true]])]);
```

* [x] State management via transaction(), commit() and abort()
* [x] Abort any open transactions on session close
* [x] Incrementing transaction numbers
* [x] Transaction options (readPreference, readConcern, writeConcern, timeoutMS, see #11 and [here](https://docs.mongodb.com/upcoming/reference/method/Session.startTransaction/#mongodb-method-Session.startTransaction))
* [x] Unittests