### PR TITLE
Change streams: Watch databases and collections for changes

### DIFF
--- a/src/main/php/com/mongodb/Collection.class.php
+++ b/src/main/php/com/mongodb/Collection.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb;
 
 use com\mongodb\io\Protocol;
-use com\mongodb\result\{Insert, Update, Delete, Cursor};
+use com\mongodb\result\{Insert, Update, Delete, Cursor, ChangeStream};
 
 /**
  * A collection inside a database.
@@ -194,5 +194,25 @@ class Collection {
     }
 
     return new Cursor($this->proto, $session, $result['body']['cursor']);
+  }
+
+  /**
+   * Watch for changes in this collection
+   *
+   * @param  [:var][] $pipeline
+   * @param  [:var] $options
+   * @param  ?com.mongodb.Session $session
+   * @return com.mongodb.result.ChangeStream
+   * @throws com.mongodb.Error
+   */
+  public function watch(array $pipeline= [], array $options= [], Session $session= null): ChangeStream {
+    array_unshift($pipeline, ['$changeStream' => (object)$options]);
+    $result= $this->proto->read($session, [
+      'aggregate' => $this->name,
+      'pipeline'  => $pipeline,
+      'cursor'    => (object)[],
+      '$db'       => $this->database,
+    ]);
+    return new ChangeStream($this->proto, $session, $result['body']['cursor']);
   }
 }

--- a/src/main/php/com/mongodb/Database.class.php
+++ b/src/main/php/com/mongodb/Database.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb;
 
 use com\mongodb\io\Protocol;
-use com\mongodb\result\Cursor;
+use com\mongodb\result\{Cursor, ChangeStream};
 
 class Database {
   private $proto, $name;
@@ -33,5 +33,25 @@ class Database {
       '$db'             => $this->name
     ]);
     return new Cursor($this->proto, $session, $result['body']['cursor']);
+  }
+
+  /**
+   * Watch for changes in this database
+   *
+   * @param  [:var][] $pipeline
+   * @param  [:var] $options
+   * @param  ?com.mongodb.Session $session
+   * @return com.mongodb.result.ChangeStream
+   * @throws com.mongodb.Error
+   */
+  public function watch(array $pipeline= [], array $options= [], Session $session= null): ChangeStream {
+    array_unshift($pipeline, ['$changeStream' => (object)$options]);
+    $result= $this->proto->read($session, [
+      'aggregate' => 1,
+      'pipeline'  => $pipeline,
+      'cursor'    => (object)[],
+      '$db'       => $this->name,
+    ]);
+    return new ChangeStream($this->proto, $session, $result['body']['cursor']);
   }
 }

--- a/src/main/php/com/mongodb/result/ChangeStream.class.php
+++ b/src/main/php/com/mongodb/result/ChangeStream.class.php
@@ -1,0 +1,9 @@
+<?php namespace com\mongodb\result;
+
+class ChangeStream extends Cursor {
+
+  /** @return ?[:var] */
+  public function resumeToken() {
+    return $this->current['postBatchResumeToken'] ?? null;
+  }
+}


### PR DESCRIPTION
Implements #14 and adds change streams:

```php
use com\mongodb\MongoConnection;
use util\cmd\Console;

$c= new MongoConnection($dsn);
$c->connect();

// Watch a collection
$cursor= $c->collection('dialog', 'entries')->watch();

// Watch a database
$cursor= $c->database('dialog')->watch();

// Watch all databases
$cursor= $c->watch();

foreach ($cursor as $change) {
  Console::writeLine('>> ', $change);
}
```