### PR TITLE
Add support for MinKey and MaxKey types

### DIFF
--- a/src/main/php/com/mongodb/MaxKey.class.php
+++ b/src/main/php/com/mongodb/MaxKey.class.php
@@ -1,0 +1,22 @@
+<?php namespace com\mongodb;
+
+use lang\Value;
+
+class MaxKey implements Value {
+
+  /** @return string */
+  public function hashCode() { return 'K7F'; }
+
+  /** @return string */
+  public function toString() { return nameof($this); }
+
+  /**
+   * Compare
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? 0 : 1;
+  }
+}

--- a/src/main/php/com/mongodb/MinKey.class.php
+++ b/src/main/php/com/mongodb/MinKey.class.php
@@ -1,0 +1,22 @@
+<?php namespace com\mongodb;
+
+use lang\Value;
+
+class MinKey implements Value {
+
+  /** @return string */
+  public function hashCode() { return 'KFF'; }
+
+  /** @return string */
+  public function toString() { return nameof($this); }
+
+  /**
+   * Compare
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? 0 : 1;
+  }
+}

--- a/src/test/php/com/mongodb/unittest/BSONTest.class.php
+++ b/src/test/php/com/mongodb/unittest/BSONTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb\unittest;
 
 use com\mongodb\io\BSON;
-use com\mongodb\{Code, Decimal128, Document, Int64, ObjectId, Regex, Timestamp};
+use com\mongodb\{Code, Decimal128, Document, Int64, MaxKey, MinKey, ObjectId, Regex, Timestamp};
 use lang\{FormatException, IllegalArgumentException};
 use unittest\{Assert, Expect, Test, Values};
 use util\{Bytes, Date, UUID};
@@ -53,6 +53,10 @@ class BSONTest {
     // Code
     yield [new Code('function () { }'), "\x0dtest\x00\x10\x00\x00\x00function () { }\x00"];
     yield [new Code('function (x, y) { return x + y; }'), "\x0dtest\x00\x22\x00\x00\x00function (x, y) { return x + y; }\x00"];
+
+    // Min and Max Keys
+    yield [new MaxKey(), "\x7ftest\x00"];
+    yield [new MinKey(), "\xfftest\x00"];
 
     // Special types
     yield [new Bytes('abc'), "\x05test\x00\x03\x00\x00\x00\x00abc"];


### PR DESCRIPTION
See https://bsonspec.org/spec.html
See https://www.mongodb.com/docs/manual/reference/bson-type-comparison-order/
See https://stackoverflow.com/questions/68991821/whatt-the-meaning-of-mongo-minkey