### PR TITLE
Add Collection::run() to run commands

### DIFF
--- a/src/main/php/com/mongodb/Collection.class.php
+++ b/src/main/php/com/mongodb/Collection.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb;
 
 use com\mongodb\io\Protocol;
-use com\mongodb\result\{Insert, Update, Delete, Cursor, ChangeStream};
+use com\mongodb\result\{Insert, Update, Delete, Cursor, Run, ChangeStream};
 
 /**
  * A collection inside a database.
@@ -27,6 +27,7 @@ class Collection {
   /**
    * Runs a command in this database
    *
+   * @deprecated Use `run()` instead!
    * @param  string $name
    * @param  [:var] $params
    * @param  ?com.mongodb.Session $session
@@ -35,6 +36,24 @@ class Collection {
    */
   public function command($name, array $params= [], Session $session= null) {
     return $this->proto->write($session, [$name => $this->name] + $params + ['$db' => $this->database])['body'];
+  }
+
+  /**
+   * Runs a command in this database
+   *
+   * @param  string $name
+   * @param  [:var] $params
+   * @param  string $method one of `read` or `write`
+   * @param  ?com.mongodb.Session $session
+   * @return com.mongodb.result.Run
+   * @throws com.mongodb.Error
+   */
+  public function run($name, array $params= [], $method= 'write', Session $session= null) {
+    return new Run(
+      $this->proto,
+      $session,
+      $this->proto->{$method}($session, [$name => $this->name] + $params + ['$db' => $this->database])
+    );
   }
 
   /**

--- a/src/main/php/com/mongodb/result/Run.class.php
+++ b/src/main/php/com/mongodb/result/Run.class.php
@@ -1,0 +1,58 @@
+<?php namespace com\mongodb\result;
+
+class Run extends Result {
+  private $proto, $session;
+  private $cursor= null;
+
+  /**
+   * Creates a new run result
+   *
+   * @see    com.mongodb.Collection::run()
+   * @param  com.mongodb.io.Protocol $proto
+   * @param  ?com.mongodb.Session $session
+   * @param  [:var] $result
+   */
+  public function __construct($proto, $session, $result) {
+    $this->proto= $proto;
+    $this->session= $session;
+    parent::__construct($result);
+  }
+
+  /** @return [:var] */
+  public function value() { return $this->result['body']; }
+
+  /** @return bool */
+  public function isCursor() { return isset($this->result['body']['cursor']); }
+
+  /**
+   * Returns this result as a cursor. Returns NULL if this result
+   * is not a cursor.
+   * 
+   * @return ?com.mongodb.result.Cursor
+   */
+  public function cursor() {
+    return $this->cursor ?? (isset($this->result['body']['cursor'])
+      ? $this->cursor= new Cursor($this->proto, $this->session, $this->result['body']['cursor'])
+      : null
+    );
+  }
+
+  /** @return void */
+  public function __destruct() {
+    if (
+      null === $this->cursor &&
+      isset($this->result['body']['cursor']) &&
+      $this->result['body']['cursor']['id']->number() > 0
+    ) {
+
+      // If cursor was previously fetched using cursor(), any remaining elements will
+      // be discarded by that Cursor instance. Otherwise, do this ourselves.
+      sscanf($this->result['body']['cursor']['ns'], "%[^.].%[^\r]", $database, $collection);
+      $this->proto->read($this->session, [
+        'killCursors' => $collection,
+        'cursors'     => [$this->result['body']['cursor']['id']],
+        '$db'         => $database,
+      ]);
+    }
+  }
+}

--- a/src/test/php/com/mongodb/unittest/CollectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionTest.class.php
@@ -53,6 +53,37 @@ class CollectionTest {
   }
 
   #[Test]
+  public function run_command() {
+    $result= $this->newFixture(['text' => 'PONG'])->run('ping');
+
+    Assert::false($result->isCursor());
+    Assert::equals(['text' => 'PONG'], $result->value());
+  }
+
+  #[Test]
+  public function run_command_as_cursor() {
+    $index= [
+      'v'                  => 2,
+      'key'                => ['_created' => 1],
+      'name'               => '_created_1',
+      'expireAfterSeconds' => 1800,
+    ];
+    $cursor= [
+      'ok'     => 1,
+      'cursor' => [
+        'id'         => new Int64(0),
+        'ns'         => 'test.sessions',
+        'firstBatch' => [$index],
+      ]
+    ];
+    $result= $this->newFixture($cursor)->run('listIndexes', []);
+
+    Assert::true($result->isCursor());
+    Assert::equals([new Document($index)], iterator_to_array($result->cursor()));
+  }
+
+
+  #[Test]
   public function insert_one() {
     $result= $this->newFixture(['ok' => 1.0, 'n' => 1])->insert(
       new Document(['_id' => 'one', 'name' => 'Test'])

--- a/src/test/php/com/mongodb/unittest/CollectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionTest.class.php
@@ -45,6 +45,7 @@ class CollectionTest {
     Assert::equals('testing.tests', (new Collection($this->protocol, 'testing', 'tests'))->namespace());
   }
 
+  /** @deprecated */
   #[Test]
   public function command() {
     $result= $this->newFixture(['text' => 'PONG'])->command('ping');


### PR DESCRIPTION
This new method replaces `Collection::command()` and handles cursor results transparently, guaranteeing to not leave any unfinished cursors hanging around.

## Old code

```php
$list= $collection->command('listIndexes, []);
foreach ($list['cursor']['firstBatch'] as $index) {
  // Work with index
}

if ($list['cursor']['id']->number() > 0) {
  // Handle next batch, either by fetching or by killing the cursor
}
```

## New code

```php
foreach ($collection->run('listIndexes, [])->cursor() as $index) {
  // Work with index
}
```

## Generic handling

```php
$result= $collection->run($name, (array)$arguments);
if ($cursor= $result->cursor()) {
  foreach ($cursor as $i => $document) {
    Console::writeLine($i, ': ', $document);
  }
} else {
  Console::writeLine($result->value());
}
```