### PR TITLE
Add Cursor::all()

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@ MongoDB for XP Framework ChangeLog
 
 ## ?.?.? / ????-??-??
 
+* Merged PR #21: Add `Collection::run()` to run commands. This deprecates
+  the *command* method, which will be removed in a future release.
+  (@thekid)
+
 ## 1.3.0 / 2022-03-29
 
 * Merged PR #19: Pick a random secondary, improving load distribution

--- a/src/main/php/com/mongodb/result/Cursor.class.php
+++ b/src/main/php/com/mongodb/result/Cursor.class.php
@@ -58,7 +58,21 @@ class Cursor implements Value, IteratorAggregate {
       return $this->current['firstBatch'] ? new Document($this->current['firstBatch'][0]) : null;
     }
 
-    throw new IllegalStateException('Cursor has been forwarded - cannot fetch first element');
+    throw new IllegalStateException('Cursor has been forwarded - cannot fetch first document');
+  }
+
+  /**
+   * Returns all documents in an array
+   *
+   * @return com.mongodb.Document[]
+   * @throws lang.IllegalStateException if the cursor has been forwarded
+   */
+  public function all() {
+    if (isset($this->current['firstBatch'])) {
+      return iterator_to_array($this);
+    }
+
+    throw new IllegalStateException('Cursor has been forwarded - cannot fetch all documents');
   }
 
   /**

--- a/src/main/php/com/mongodb/result/Cursor.class.php
+++ b/src/main/php/com/mongodb/result/Cursor.class.php
@@ -27,7 +27,7 @@ class Cursor implements Value, IteratorAggregate {
 
   /** Iterates all documents, fetching batches as necessary */
   public function getIterator(): Traversable {
-    foreach ($this->current['firstBatch'] as $document) {
+    foreach ($this->current['firstBatch'] ?? [] as $document) {
       yield new Document($document);
     }
 

--- a/src/main/php/com/mongodb/result/Cursor.class.php
+++ b/src/main/php/com/mongodb/result/Cursor.class.php
@@ -48,6 +48,15 @@ class Cursor implements Value, IteratorAggregate {
   }
 
   /**
+   * Returns whether any documents are present in this cursor.
+   *
+   * @return bool
+   */
+  public function present() {
+    return !empty($this->current['firstBatch'] ?? $this->current['nextBatch'] ?? null);
+  }
+
+  /**
    * Returns the first document, if there is one; NULL otherwise
    *
    * @return ?com.mongodb.Document
@@ -73,15 +82,6 @@ class Cursor implements Value, IteratorAggregate {
     }
 
     throw new IllegalStateException('Cursor has been forwarded - cannot fetch all documents');
-  }
-
-  /**
-   * Returns whether any documents are present in this cursor.
-   *
-   * @return bool
-   */
-  public function present() {
-    return !empty($this->current['firstBatch'] ?? $this->current['nextBatch'] ?? null);
   }
 
   /**

--- a/src/test/php/com/mongodb/unittest/result/CursorTest.class.php
+++ b/src/test/php/com/mongodb/unittest/result/CursorTest.class.php
@@ -103,7 +103,39 @@ class CursorTest {
     );
     iterator_count($fixture);
 
-    Assert::null($fixture->first());
+    $fixture->first();
+  }
+
+  #[Test]
+  public function all_documents() {
+    $documents= [['_id' => 'one', 'qty'  => 1000], ['_id' => 'two', 'qty'  => 6100]];
+    $fixture= new Cursor($this->proto, null, $this->firstBatch($documents));
+
+    Assert::equals(
+      array_map(function($d) { return new Document($d); }, $documents),
+      $fixture->all()
+    );
+  }
+
+  #[Test]
+  public function all_when_not_found() {
+    $documents= [];
+    $fixture= new Cursor($this->proto, null, $this->firstBatch());
+
+    Assert::equals([], $fixture->all());
+  }
+
+  #[Test, Expect(class: IllegalStateException::class, withMessage: '/Cursor has been forwarded/')]
+  public function all_after_iterating() {
+    $documents= [['_id' => 'one', 'qty'  => 1000], ['_id' => 'two', 'qty'  => 6100]];
+    $fixture= new Cursor(
+      $this->proto->returning([$this->nextBatch([$documents[1]], true)]),
+      null,
+      $this->firstBatch([$documents[0]], false)
+    );
+    iterator_count($fixture);
+
+    $fixture->all();
   }
 
   #[Test]


### PR DESCRIPTION
This PR adds an *all* method to `com.mongodb.result.Cursor`.

## Current code, continues to work

```php
$documents= iterator_to_array($collection->aggregate($pipeline));
```

## New and more concise code

```php
$documents= $collection->aggregate($pipeline)->all();
```

The new method will raise an exception if the cursor has already been forwarded.