### PR TITLE
Add Collection::upsert()

### DIFF
--- a/src/main/php/com/mongodb/Collection.class.php
+++ b/src/main/php/com/mongodb/Collection.class.php
@@ -85,6 +85,29 @@ class Collection {
   }
 
   /**
+   * Upserts collection with given modifications.
+   *
+   * @param  string|com.mongodb.ObjectId|[:var] $query
+   * @param  [:var] $statements Update operator expressions
+   * @param  ?com.mongodb.Session $session
+   * @return com.mongodb.result.Update
+   * @throws com.mongodb.Error
+   */
+  public function upsert($query, $statements, Session $session= null): Update {
+    $result= $this->proto->write($session, [
+      'update'    => $this->name,
+      'updates'   => [[
+        'q'      => $query instanceof ObjectId ? ['_id' => $query] : $query,
+        'u'      => $statements,
+        'upsert' => true,
+        'multi'  => false
+      ]],
+      '$db'       => $this->database,
+    ]);
+    return new Update($result['body']);
+  }
+
+  /**
    * Updates collection with given modifications.
    *
    * @param  string|com.mongodb.ObjectId|[:var] $query

--- a/src/main/php/com/mongodb/Collection.class.php
+++ b/src/main/php/com/mongodb/Collection.class.php
@@ -88,17 +88,17 @@ class Collection {
    * Upserts collection with given modifications.
    *
    * @param  string|com.mongodb.ObjectId|[:var] $query
-   * @param  [:var] $statements Update operator expressions
+   * @param  [:var]|com.mongodb.Document $arg Update operator expressions or document
    * @param  ?com.mongodb.Session $session
    * @return com.mongodb.result.Update
    * @throws com.mongodb.Error
    */
-  public function upsert($query, $statements, Session $session= null): Update {
+  public function upsert($query, $arg, Session $session= null): Update {
     $result= $this->proto->write($session, [
       'update'    => $this->name,
       'updates'   => [[
         'q'      => $query instanceof ObjectId ? ['_id' => $query] : $query,
-        'u'      => $statements,
+        'u'      => $arg,
         'upsert' => true,
         'multi'  => false
       ]],

--- a/src/main/php/com/mongodb/result/Update.class.php
+++ b/src/main/php/com/mongodb/result/Update.class.php
@@ -9,4 +9,16 @@ class Update extends Result {
   /** Returns number of modified documents */
   public function modified(): int { return $this->result['nModified']; }
 
+  /**
+   * Returns IDs from an upsert, or an empty array if no upsers were performed.
+   *
+   * @return (string|com.mongodb.ObjectId)[]
+   */
+  public function upserted(): array {
+    $r= [];
+    foreach ($this->result['upserted'] ?? [] as $upsert) {
+      $r[]= $upsert['_id'];
+    }
+    return $r;
+  }
 }

--- a/src/test/php/com/mongodb/unittest/CollectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionTest.class.php
@@ -107,7 +107,7 @@ class CollectionTest {
   public function upsert_when_updating() {
     $result= $this->newFixture(['ok' => 1.0, 'n' => 1, 'nModified' => 1])->upsert(
       ['_id' => 'one'],
-      new Document(['_id' => 'one', 'name' => 'A']),
+      new Document(['_id' => 'one', 'name' => 'A'])
     );
 
     Assert::equals([1, 1, []], [$result->matched(), $result->modified(), $result->upserted()]);
@@ -118,7 +118,7 @@ class CollectionTest {
     $upsert= ['index' => 0, '_id' => new ObjectId('631c6206306c05628f1caff7')];
     $result= $this->newFixture(['ok' => 1.0, 'n' => 1, 'nModified' => 0, 'upserted' => [$upsert]])->upsert(
       ['_id' => 'one'],
-      new Document(['_id' => 'one', 'name' => 'A']),
+      new Document(['_id' => 'one', 'name' => 'A'])
     );
 
     Assert::equals([1, 0, [$upsert['_id']]], [$result->matched(), $result->modified(), $result->upserted()]);

--- a/src/test/php/com/mongodb/unittest/CollectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb\unittest;
 
 use com\mongodb\io\Protocol;
-use com\mongodb\{Collection, Document, Int64};
+use com\mongodb\{Collection, Document, ObjectId, Int64};
 use unittest\{Assert, Before, Test};
 
 class CollectionTest {
@@ -101,6 +101,27 @@ class CollectionTest {
     ]);
 
     Assert::equals([2, ['one', 'two']], [$result->inserted(), $result->ids()]);
+  }
+
+  #[Test]
+  public function upsert_when_updating() {
+    $result= $this->newFixture(['ok' => 1.0, 'n' => 1, 'nModified' => 1])->upsert(
+      ['_id' => 'one'],
+      new Document(['_id' => 'one', 'name' => 'A']),
+    );
+
+    Assert::equals([1, 1, []], [$result->matched(), $result->modified(), $result->upserted()]);
+  }
+
+  #[Test]
+  public function upsert_when_inserting() {
+    $upsert= ['index' => 0, '_id' => new ObjectId('631c6206306c05628f1caff7')];
+    $result= $this->newFixture(['ok' => 1.0, 'n' => 1, 'nModified' => 0, 'upserted' => [$upsert]])->upsert(
+      ['_id' => 'one'],
+      new Document(['_id' => 'one', 'name' => 'A']),
+    );
+
+    Assert::equals([1, 0, [$upsert['_id']]], [$result->matched(), $result->modified(), $result->upserted()]);
   }
 
   #[Test]

--- a/src/test/php/com/mongodb/unittest/result/UpdateTest.class.php
+++ b/src/test/php/com/mongodb/unittest/result/UpdateTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace com\mongodb\unittest\result;
 
+use com\mongodb\ObjectId;
 use com\mongodb\result\Update;
 use unittest\{Assert, Test};
 
@@ -19,6 +20,17 @@ class UpdateTest {
   #[Test]
   public function modified() {
     Assert::equals(0, (new Update(self::RESULT))->modified());
+  }
+
+  #[Test]
+  public function upserted() {
+    $upsert= ['index' => 0, '_id' => new ObjectId('631c6206306c05628f1caff7')];
+    Assert::equals([$upsert['_id']], (new Update(self::RESULT + ['upserted' => [$upsert]]))->upserted());
+  }
+
+  #[Test]
+  public function no_upsert() {
+    Assert::equals([], (new Update(self::RESULT))->upserted());
   }
 
   #[Test]


### PR DESCRIPTION
This pull request adds an `upsert()` method which calls the *update* command with *upsert: true*. It greatly simplifies and optimizes code along the line of the following:

```php
$entry= new Document(/*...*/);

// Old code, executes 2 commands
if ($first= $collection->find(['slug' => 'test'])->first()) {
  $collection->update($first->id(), $entry);
} else {
  $collection->insert($entry);
}

// New code, only ever executes 1 command
$collection->upsert(['slug' => 'test'], $entry);
```

See https://www.mongodb.com/docs/manual/reference/command/update/#std-label-update-command-upsert