### PR TITLE
Add MongoConnection::protocol()

### DIFF
--- a/src/main/php/com/mongodb/MongoConnection.class.php
+++ b/src/main/php/com/mongodb/MongoConnection.class.php
@@ -34,6 +34,9 @@ class MongoConnection implements Value {
     $this->proto= $arg instanceof Protocol ? $arg : new Protocol($arg);
   }
 
+  /** @return com.mongodb.io.Protocol */
+  public function protocol() { return $this->proto; }
+
   /**
    * Connects and returns this connection
    *

--- a/src/main/php/com/mongodb/io/Connection.class.php
+++ b/src/main/php/com/mongodb/io/Connection.class.php
@@ -54,14 +54,12 @@ class Connection {
       $this->socket= new Socket($arg, $port);
     } else if ($arg instanceof Socket) {
       $this->socket= $arg;
+    } else if ('[' === $arg[0]) {
+      sscanf($arg, '[%[0-9a-fA-F:]]:%d', $host, $port);
+      $this->socket= new Socket("[{$host}]", $port ?? 27017);
     } else {
-      if ('[' === $arg[0]) {
-        sscanf($arg, '[%[0-9a-fA-F:]]:%d', $host, $port);
-        $this->socket= new Socket("[{$host}]", $port ?? 27017);
-      } else {
-        sscanf($arg, '%[^:]:%d', $host, $port);
-        $this->socket= new Socket($host, $port ?? 27017);
-      }
+      sscanf($arg, '%[^:]:%d', $host, $port);
+      $this->socket= new Socket($host, $port ?? 27017);
     }
     $this->bson= $bson ?: new BSON();
   }

--- a/src/main/php/com/mongodb/io/Connection.class.php
+++ b/src/main/php/com/mongodb/io/Connection.class.php
@@ -57,20 +57,18 @@ class Connection {
     } else {
       if ('[' === $arg[0]) {
         sscanf($arg, '[%[0-9a-fA-F:]]:%d', $host, $port);
+        $this->socket= new Socket("[{$host}]", $port ?? 27017);
       } else {
         sscanf($arg, '%[^:]:%d', $host, $port);
+        $this->socket= new Socket($host, $port ?? 27017);
       }
-      $this->socket= new Socket($host, $port ?? 27017);
     }
     $this->bson= $bson ?: new BSON();
   }
 
   /** @return string */
   public function address() {
-    return false === strpos($this->socket->host, ':')
-      ? $this->socket->host.':'.$this->socket->port
-      : '['.$this->socket->host.']:'.$this->socket->port
-    ;
+    return $this->socket->host.':'.$this->socket->port;
   }
 
   /** @return bool */

--- a/src/test/php/com/mongodb/unittest/MongoConnectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/MongoConnectionTest.class.php
@@ -34,6 +34,11 @@ class MongoConnectionTest {
   }
 
   #[Test]
+  public function protocol_dsn() {
+    Assert::equals(self::DSN, (new MongoConnection(self::DSN))->protocol()->dsn());
+  }
+
+  #[Test]
   public function two_connections_are_not_equal() {
     $one= new MongoConnection(self::DSN);
     $two= new MongoConnection(self::DSN);

--- a/src/test/php/com/mongodb/unittest/ProtocolTest.class.php
+++ b/src/test/php/com/mongodb/unittest/ProtocolTest.class.php
@@ -26,6 +26,16 @@ class ProtocolTest {
     );
   }
 
+  #[Test, Values(['mongodb://localhost', 'mongodb://localhost?tls=true', 'mongodb://u:p@localhost', 'mongodb://one.local,two.local:27018,[::1]:27019'])]
+  public function dsn_via_connection_string($uri) {
+    Assert::equals($uri, (new Protocol($uri))->dsn(true));
+  }
+
+  #[Test]
+  public function dsn_without_password() {
+    Assert::equals('mongodb://u:****@localhost', (new Protocol('mongodb://u:pass@localhost'))->dsn(false));
+  }
+
   #[Test]
   public function cluster_via_connection_string() {
     $fixture= new Protocol('mongodb://one.local,two.local:27018,[::1]:27019');
@@ -66,5 +76,6 @@ class ProtocolTest {
 
     Assert::equals(['mongo01.example.com:27017', 'mongo02.example.com:27317'], array_keys($p->connections()));
     Assert::equals(['replicaSet' => 'mySet', 'ssl' => 'true'], $p->options()['params']);
+    Assert::equals('mongodb+srv://example.com?ssl=true&replicaSet=mySet', $p->dsn());
   }
 }


### PR DESCRIPTION
This PR adds a new method `protocol()` to the `MongoConnection` class. It returns the associated protocol instance, which has the following API:

```php
public class com.mongodb.io.Protocol {
  public var $nodes
  public var $readPreference
  public var $socketCheckInterval

  public function __construct(
    string|com.mongodb.io.Connection[] $arg,
    [:string] $options,
    com.mongodb.io.BSON $bson,
    com.mongodb.io.DNS $dns
  )

  public function options(): [:var]
  public function connections(): [:com.mongodb.io.Connection]
  public function dsn(bool $password): string
  public function connect(): self
  public function read(?com.mongodb.Session $session, [:var] $sections): var
  public function write(?com.mongodb.Session $session, [:var] $sections): var
  public function close(): void
}
```