### PR TITLE
Fix DNS errors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@ MongoDB for XP Framework ChangeLog
 
 ## ?.?.? / ????-??-??
 
+* Merged PR #30: Migrate to new testing library - @thekid
+
 ## 1.9.2 / 2023-01-15
 
 * Added fix for #28 - reconnecting when using readPreference *nearest*

--- a/src/main/php/com/mongodb/CannotConnect.class.php
+++ b/src/main/php/com/mongodb/CannotConnect.class.php
@@ -1,0 +1,12 @@
+<?php namespace com\mongodb;
+
+/**
+ * Indicates connection failed
+ *
+ * @see  com.mongodb.MongoConnection::connect()
+ * @see  com.mongodb.NoSuitableCandidate
+ * @see  https://github.com/xp-forge/mongodb/pull/32
+ */
+class CannotConnect extends Error {
+
+}

--- a/src/main/php/com/mongodb/NoSuitableCandidate.class.php
+++ b/src/main/php/com/mongodb/NoSuitableCandidate.class.php
@@ -3,7 +3,7 @@
 use lang\Throwable;
 
 /** @test com.mongodb.unittest.NoSuitableCandidateTest */
-class NoSuitableCandidate extends Error {
+class NoSuitableCandidate extends CannotConnect {
   private $candidates;
 
   public function __construct(string $intent, array $candidates, Throwable $cause= null) {

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\mongodb\io;
 
-use com\mongodb\{Authentication, NoSuitableCandidate, Error};
+use com\mongodb\{Authentication, NoSuitableCandidate, CannotConnect};
 use io\IOException;
 use lang\{IllegalStateException, IllegalArgumentException, Throwable};
 use peer\{ConnectException, Socket, SocketException};
@@ -60,11 +60,11 @@ class Protocol {
             $p.= '&'.$param;
           }
         } catch (IOException $e) {
-          throw new Error(231, 'DNSProtocolError', 'DNS lookup failed for '.$m[5], $e);
+          throw new CannotConnect(231, 'DNSProtocolError', 'DNS lookup failed for '.$m[5], $e);
         }
 
         if (empty($this->conn)) {
-          throw new Error(230, 'DNSHostNotFound', 'DNS does not contain MongoDB SRV records for '.$m[5]);
+          throw new CannotConnect(230, 'DNSHostNotFound', 'DNS does not contain MongoDB SRV records for '.$m[5]);
         }
 
         // As per spec: Use of the +srv connection string modifier automatically sets the tls

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -1,6 +1,7 @@
 <?php namespace com\mongodb\io;
 
-use com\mongodb\{Authentication, NoSuitableCandidate};
+use com\mongodb\{Authentication, NoSuitableCandidate, Error};
+use io\IOException;
 use lang\{IllegalStateException, IllegalArgumentException, Throwable};
 use peer\{ConnectException, Socket, SocketException};
 use util\Objects;
@@ -12,7 +13,8 @@ use util\Objects;
  * @test  com.mongodb.unittest.ReplicaSetTest
  */
 class Protocol {
-  private $options, $conn, $auth;
+  private $options, $auth;
+  private $conn= [];
   public $nodes= null;
   public $readPreference;
   public $socketCheckInterval= 5;
@@ -33,7 +35,6 @@ class Protocol {
 
     if (is_array($arg)) {
       $nodes= '';
-      $this->conn= [];
       foreach ($arg as $conn) {
         $nodes.= ','.$conn->address();
         $this->conn[$conn->address()]= $conn;
@@ -50,12 +51,20 @@ class Protocol {
       if ('mongodb+srv' === $m[1]) {
         $dns ?? $dns= new DNS();
 
-        foreach ($dns->members($m[5]) as $host => $port) {
-          $conn= new Connection($host, $port, $bson);
-          $this->conn[$conn->address()]= $conn;
+        try {
+          foreach ($dns->members($m[5]) as $host => $port) {
+            $conn= new Connection($host, $port, $bson);
+            $this->conn[$conn->address()]= $conn;
+          }
+          foreach ($dns->params($m[5]) as $param) {
+            $p.= '&'.$param;
+          }
+        } catch (IOException $e) {
+          throw new Error(231, 'DNSProtocolError', 'DNS lookup failed for '.$m[5], $e);
         }
-        foreach ($dns->params($m[5]) as $param) {
-          $p.= '&'.$param;
+
+        if (empty($this->conn)) {
+          throw new Error(230, 'DNSHostNotFound', 'DNS does not contain MongoDB SRV records for '.$m[5]);
         }
 
         // As per spec: Use of the +srv connection string modifier automatically sets the tls


### PR DESCRIPTION
This pull request fixes DNS error handling for the following situations:

* Lookup fails due to DNS errors
* Lookup does not find a mongodb SRV record - see #31 

In both cases, a `com.mongodb.CannotConnect` instance is thrown. 

* * * 

Boy scout principle: The *NoSuitableCandidate* error is made to extend this new exception so all connection errors can be handled by catching a single exception class.