### PR TITLE
Add Document::merge()

### DIFF
--- a/src/main/php/com/mongodb/Document.class.php
+++ b/src/main/php/com/mongodb/Document.class.php
@@ -61,6 +61,26 @@ class Document implements Value, ArrayAccess, IteratorAggregate {
     unset($this->properties[$name]);
   }
 
+  /**
+   * Merge a given property with a given list or map
+   *
+   * @see    https://www.php.net/array_merge
+   * @param  string $name
+   * @param  iterable $from
+   * @return self
+   */
+  public function merge($name, $from) {
+    $prop= &$this->properties[$name];
+    if (empty($prop)) {
+      $prop= is_array($from) ? $from : iterator_to_array($from);
+    } else if (0 === key($prop)) {
+      foreach ($from as $value) $prop[]= $value;
+    } else {
+      foreach ($from as $key => $value) $prop[$key]= $value;
+    }
+    return $this;
+  }
+
   /** Iterator over all properties */
   public function getIterator(): Traversable { yield from $this->properties; }
 

--- a/src/main/php/com/mongodb/Document.class.php
+++ b/src/main/php/com/mongodb/Document.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\mongodb;
 
-use ArrayAccess, Traversable, IteratorAggregate, ReturnTypeWillChange;
+use ArrayAccess, Traversable, IteratorAggregate, ReturnTypeWillChange, StdClass;
 use lang\{Value, IllegalArgumentException};
 use util\Objects;
 
@@ -74,9 +74,8 @@ class Document implements Value, ArrayAccess, IteratorAggregate {
     $prop= &$this->properties[$name];
     if (empty($prop)) {
       $prop= is_array($from) ? $from : iterator_to_array($from);
-    } else if ($prop instanceof \StdClass) {
-      $prop= (array)$prop;
-      foreach ($from as $key => $value) $prop[$key]= $value;
+    } else if ($prop instanceof StdClass) {
+      foreach ($from as $key => $value) $prop->{$key}= $value;
     } else if (!is_array($prop)) {
       throw new IllegalArgumentException('Cannot merge scalar property '.$name);
     } else if (0 === key($prop)) {

--- a/src/test/php/com/mongodb/unittest/DocumentTest.class.php
+++ b/src/test/php/com/mongodb/unittest/DocumentTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb\unittest;
 
 use com\mongodb\{Document, ObjectId};
-use lang\IndexOutOfBoundsException;
+use lang\{IndexOutOfBoundsException, IllegalArgumentException};
 use test\{Assert, Before, Expect, Test, Values};
 
 class DocumentTest {
@@ -107,6 +107,22 @@ class DocumentTest {
     $f= function() { yield 'two' => 2; };
     $fixture= (new Document(['map' => $initial]))->merge('map', $f());
     Assert::equals($expected, $fixture['map']);
+  }
+
+  #[Test, Values([[[], ['two' => 2]], [['one' => 1], ['one' => 1, 'two' => 2]]])]
+  public function merge_object($initial, $expected) {
+    $fixture= (new Document(['map' => (object)$initial]))->merge('map', ['two' => 2]);
+    Assert::equals($expected, $fixture['map']);
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function merge_scalar() {
+    (new Document(['item' => 1]))->merge('item', [2]);
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function merge_object_id() {
+    (new Document(['_id' => ObjectId::create()]))->merge('_id', [2]);
   }
 
   #[Test, Values(from: 'representations')]

--- a/src/test/php/com/mongodb/unittest/DocumentTest.class.php
+++ b/src/test/php/com/mongodb/unittest/DocumentTest.class.php
@@ -112,7 +112,7 @@ class DocumentTest {
   #[Test, Values([[[], ['two' => 2]], [['one' => 1], ['one' => 1, 'two' => 2]]])]
   public function merge_object($initial, $expected) {
     $fixture= (new Document(['map' => (object)$initial]))->merge('map', ['two' => 2]);
-    Assert::equals($expected, $fixture['map']);
+    Assert::equals((object)$expected, $fixture['map']);
   }
 
   #[Test, Expect(IllegalArgumentException::class)]

--- a/src/test/php/com/mongodb/unittest/DocumentTest.class.php
+++ b/src/test/php/com/mongodb/unittest/DocumentTest.class.php
@@ -83,6 +83,32 @@ class DocumentTest {
     Assert::false(isset($fixture['exists']));
   }
 
+  #[Test, Values([[null, [3]], [[], [3]], [[1, 2], [1, 2, 3]]])]
+  public function merge_list($initial, $expected) {
+    $fixture= (new Document(['list' => $initial]))->merge('list', [3]);
+    Assert::equals($expected, $fixture['list']);
+  }
+
+  #[Test, Values([[null, ['two' => 2]], [[], ['two' => 2]], [['one' => 1], ['one' => 1, 'two' => 2]]])]
+  public function merge_map($initial, $expected) {
+    $fixture= (new Document(['map' => $initial]))->merge('map', ['two' => 2]);
+    Assert::equals($expected, $fixture['map']);
+  }
+
+  #[Test, Values([[null, [3]], [[], [3]], [[1, 2], [1, 2, 3]]])]
+  public function merge_iterable($initial, $expected) {
+    $f= function() { yield 3; };
+    $fixture= (new Document(['list' => $initial]))->merge('list', $f());
+    Assert::equals($expected, $fixture['list']);
+  }
+
+  #[Test, Values([[null, ['two' => 2]], [[], ['two' => 2]], [['one' => 1], ['one' => 1, 'two' => 2]]])]
+  public function merge_iterable_with_key($initial, $expected) {
+    $f= function() { yield 'two' => 2; };
+    $fixture= (new Document(['map' => $initial]))->merge('map', $f());
+    Assert::equals($expected, $fixture['map']);
+  }
+
   #[Test, Values(from: 'representations')]
   public function string_representation($fields, $expected) {
     Assert::equals($expected, (new Document($fields))->toString());


### PR DESCRIPTION
This pull request adds a `merge()` method to the *Document* class. It modifies list and map properties like PHP's *array_merge()* function.

```php
use com\mongodb\{Document, ObjectId};

$doc= new Document(['_id' => ObjectId::create(), 'list' => [1, 2, 3]]);

// This does not work - offsetGet() creates a copy of the array!
$doc['list'][]= 4;

// What we need to do
$doc['list']= array_merge($doc['list'] ?? [], [4]);

// New functionality:
$doc->merge('list', [4]);
```