### PR TITLE
Make it possible to omit regex modifiers

### DIFF
--- a/src/main/php/com/mongodb/Regex.class.php
+++ b/src/main/php/com/mongodb/Regex.class.php
@@ -1,14 +1,17 @@
 <?php namespace com\mongodb;
 
+/** @test com.mongodb.unittest.RegexTest */
 class Regex {
   private $pattern, $modifiers;
 
-  public function __construct($pattern, $modifiers) {
+  public function __construct($pattern, $modifiers= '') {
     $this->pattern= $pattern;
     $this->modifiers= $modifiers;
   }
 
+  /** @return string */
   public function pattern() { return $this->pattern; }
 
+  /** @return string */
   public function modifiers() { return $this->modifiers; }
 }

--- a/src/test/php/com/mongodb/unittest/RegexTest.class.php
+++ b/src/test/php/com/mongodb/unittest/RegexTest.class.php
@@ -1,0 +1,28 @@
+<?php namespace com\mongodb\unittest;
+
+use com\mongodb\Regex;
+use test\{Assert, Test, Values};
+
+class RegexTest {
+  const PATTERN= '<a href="([^"]+)">';
+
+  #[Test]
+  public function can_create() {
+    new Regex(self::PATTERN);
+  }
+
+  #[Test]
+  public function defaults_to_empty_modifiers() {
+    Assert::equals('', (new Regex(self::PATTERN))->modifiers());
+  }
+
+  #[Test, Values(['', 'i', 'im'])]
+  public function modifiers($arg) {
+    Assert::equals($arg, (new Regex(self::PATTERN, $arg))->modifiers());
+  }
+
+  #[Test]
+  public function pattern() {
+    Assert::equals(self::PATTERN, (new Regex(self::PATTERN))->pattern());
+  }
+}


### PR DESCRIPTION
```php
// Before, we needed to pass in an empty string
$regex= new Regex('<a href="[^"]+">', '');

// Now, we can simply omit this to the same effect
$regex= new Regex('<a href="[^"]+">');
```

See also https://www.mongodb.com/docs/manual/reference/operator/query/regex/