### PR TITLE
Return document properties by reference

### DIFF
--- a/src/main/php/com/mongodb/Document.class.php
+++ b/src/main/php/com/mongodb/Document.class.php
@@ -36,11 +36,13 @@ class Document implements Value, ArrayAccess, IteratorAggregate {
    */
   #[ReturnTypeWillChange]
   public function &offsetGet($name) {
+
+    // Double-check with array_key_exists() should the property be null.
     if (isset($this->properties[$name]) || array_key_exists($name, $this->properties)) {
       return $this->properties[$name];
     }
 
-    throw new IndexOutOfBoundsException($name);
+    throw new IndexOutOfBoundsException('Undefined property "'.$name.'"');
   }
 
   /**

--- a/src/main/php/com/mongodb/Document.class.php
+++ b/src/main/php/com/mongodb/Document.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb;
 
 use ArrayAccess, Traversable, IteratorAggregate, ReturnTypeWillChange;
-use lang\Value;
+use lang\{Value, IndexOutOfBoundsException};
 use util\Objects;
 
 class Document implements Value, ArrayAccess, IteratorAggregate {
@@ -28,14 +28,19 @@ class Document implements Value, ArrayAccess, IteratorAggregate {
   }
 
   /**
-   * Read access overloading
+   * Read access overloading. Returns a reference!
    *
    * @param  string $name
-   * @return bool
+   * @return var
+   * @throws lang.IndexOutOfBoundsException
    */
   #[ReturnTypeWillChange]
-  public function offsetGet($name) {
-    return $this->properties[$name];
+  public function &offsetGet($name) {
+    if (isset($this->properties[$name]) || array_key_exists($name, $this->properties)) {
+      return $this->properties[$name];
+    }
+
+    throw new IndexOutOfBoundsException($name);
   }
 
   /**

--- a/src/test/php/com/mongodb/unittest/DocumentTest.class.php
+++ b/src/test/php/com/mongodb/unittest/DocumentTest.class.php
@@ -51,7 +51,7 @@ class DocumentTest {
     Assert::equals('value', $fixture['exists']);
   }
 
-  #[Test, Expect(IndexOutOfBoundsException::class)]
+  #[Test, Expect(class: IndexOutOfBoundsException::class, message: 'Undefined property "absent"')]
   public function read_non_existant_offset() {
     $fixture= new Document(['exists' => 'value']);
     $r= $fixture['absent'];

--- a/src/test/php/com/mongodb/unittest/DocumentTest.class.php
+++ b/src/test/php/com/mongodb/unittest/DocumentTest.class.php
@@ -51,6 +51,12 @@ class DocumentTest {
     Assert::equals('value', $fixture['exists']);
   }
 
+  #[Test]
+  public function read_null_offset() {
+    $fixture= new Document(['exists' => null]);
+    Assert::equals(null, $fixture['exists']);
+  }
+
   #[Test, Expect(class: IndexOutOfBoundsException::class, message: 'Undefined property "absent"')]
   public function read_non_existant_offset() {
     $fixture= new Document(['exists' => 'value']);

--- a/src/test/php/com/mongodb/unittest/DocumentTest.class.php
+++ b/src/test/php/com/mongodb/unittest/DocumentTest.class.php
@@ -52,7 +52,7 @@ class DocumentTest {
   }
 
   #[Test, Expect(IndexOutOfBoundsException::class)]
-  public function read_non_exstant_offset() {
+  public function read_non_existant_offset() {
     $fixture= new Document(['exists' => 'value']);
     $r= $fixture['absent'];
   }
@@ -86,5 +86,19 @@ class DocumentTest {
   #[Test, Values(from: 'representations')]
   public function string_representation($fields, $expected) {
     Assert::equals($expected, (new Document($fields))->toString());
+  }
+
+  #[Test]
+  public function sort_offset_array() {
+    $fixture= new Document(['list' => [1, 3, 2]]);
+    sort($fixture['list']);
+    Assert::equals([1, 2, 3], $fixture['list']);
+  }
+
+  #[Test]
+  public function append_to_offset_array() {
+    $fixture= new Document(['list' => [1, 2, 3]]);
+    $fixture['list'][]= 4;
+    Assert::equals([1, 2, 3, 4], $fixture['list']);
   }
 }

--- a/src/test/php/com/mongodb/unittest/DocumentTest.class.php
+++ b/src/test/php/com/mongodb/unittest/DocumentTest.class.php
@@ -107,4 +107,11 @@ class DocumentTest {
     $fixture['list'][]= 4;
     Assert::equals([1, 2, 3, 4], $fixture['list']);
   }
+
+  #[Test]
+  public function set_offset_array_key() {
+    $fixture= new Document(['properties' => ['color' => 'green']]);
+    $fixture['properties']['price']= 12.99;
+    Assert::equals(['color' => 'green', 'price' => 12.99], $fixture['properties']);
+  }
 }


### PR DESCRIPTION
Adhering to the principle of least surprise.

## Before

```php
$doc= new Document(['list' => [1, 3, 2]]);

sort($doc['list']);
var_dump($doc['list']);  // remains unsorted: [1, 3, 2]

$doc['list'][]= 4;
var_dump($doc['list']);  // remains unchanged: [1, 3, 2]
```

## After

```php
$doc= new Document(['list' => [1, 3, 2]]);

sort($doc['list']);
var_dump($doc['list']);  // sorted: [1, 2, 3]

$doc['list'][]= 4;
var_dump($doc['list']);  // includes added value: [1, 2, 3, 4]
```