### PR TITLE
Implement SCRAM-SHA-256 authentication

### DIFF
--- a/src/main/php/com/mongodb/Authentication.class.php
+++ b/src/main/php/com/mongodb/Authentication.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\mongodb;
 
-use com\mongodb\auth\{Mechanism, ScramSHA1};
+use com\mongodb\auth\{Mechanism, ScramSHA1, ScramSHA256};
 use lang\IllegalArgumentException;
 
 abstract class Authentication {
@@ -13,7 +13,7 @@ abstract class Authentication {
   public static function mechanism(string $name): Mechanism {
     switch ($name) {
       case 'SCRAM-SHA-1': return new ScramSHA1();
-      // case 'SCRAM-SHA-256': return new ScramSHA256();
+      case 'SCRAM-SHA-256': return new ScramSHA256();
       default: throw new IllegalArgumentException('Unknown authentication mechanism '.$name);
     }
   }

--- a/src/main/php/com/mongodb/auth/Scram.class.php
+++ b/src/main/php/com/mongodb/auth/Scram.class.php
@@ -1,0 +1,104 @@
+<?php namespace com\mongodb\auth;
+
+use lang\IllegalStateException;
+use util\Bytes;
+
+/**
+ * Salted Challenge Response Authentication Mechanism (SCRAM) is the default
+ * authentication mechanism for MongoDB.
+ *
+ * @see   https://docs.mongodb.com/manual/core/security-scram/
+ */
+abstract class Scram implements Mechanism {
+  protected $nonce= null;
+
+  /** Creates a new instance, initializing nonce */
+  public function __construct() {
+    $this->nonce= function() { return base64_encode(random_bytes(24)); };
+  }
+
+  /**
+   * Use the given function to generate nonce values
+   *
+   * @param  function(): string $callable
+   * @return self
+   */
+  public function nonce($callable) {
+    $this->nonce= $callable;
+    return $this;
+  }
+
+  /**
+   * Parses `k=...,r=...` into a map
+   *
+   * @param  string $bytes
+   * @return [:string]
+   */
+  protected function pairs($bytes) {
+    $pairs= [];
+    foreach (explode(',', $bytes) as $pair) {
+      sscanf($pair, "%[^=]=%[^\r]", $key, $value);
+      $pairs[$key]= $value;
+    }
+    return $pairs;
+  }
+
+  /**
+   * Returns a conversation dialogue yielding and receiving client and server
+   * payloads, respectively.
+   *
+   * @return iterable
+   */
+  public function conversation(string $username, string $password, string $authsource) {
+
+    // Step 1: Initiate conversation with username and a random nonce
+    $gs2= 'n,,';
+    $nonce= ($this->nonce)();
+    $c1b= 'n='.$username.',r='.$nonce;
+
+    $first= yield [
+      'saslStart' => 1,
+      'mechanism' => static::MECHANISM,
+      'payload'   => new Bytes($gs2.$c1b),
+      '$db'       => $authsource,
+    ];
+
+    $pairs= $this->pairs($first['payload']);
+    if (0 !== substr_compare($pairs['r'], $nonce, 0, strlen($nonce))) {
+      throw new IllegalStateException('Server did not extend client nonce '.$nonce.' ('.$pairs['r'].')');
+    }
+
+    if ($pairs['i'] < static::MIN_ITERATIONS) {
+      throw new IllegalStateException('Server requested less than '.static::MIN_ITERATIONS.' iterations ('.$pairs['i'].')');
+    }
+
+    // Step 2: User server-supplied nonce and hash password
+    $c2wop= 'c='.base64_encode($gs2).',r='.$pairs['r'];
+    $message= $c1b.','.$first['payload'].','.$c2wop;
+    $salted= hash_pbkdf2(static::HASH_ALGORITHM, $password, base64_decode($pairs['s']), (int)$pairs['i'], 0, true);
+    $client= hash_hmac(static::HASH_ALGORITHM, 'Client Key', $salted, true);
+    $server= hash_hmac(static::HASH_ALGORITHM, 'Server Key', $salted, true);
+    $signature= hash_hmac(static::HASH_ALGORITHM, $message, hash(static::HASH_ALGORITHM, $client, true), true);
+
+    $next= yield [
+      'saslContinue'   => 1,
+      'payload'        => new Bytes($c2wop.',p='.base64_encode($client ^ $signature)),
+      'conversationId' => $first['conversationId'],
+      '$db'            => $authsource,
+    ];
+
+    $pairs= $this->pairs($next['payload']);
+    $signature= hash_hmac(static::HASH_ALGORITHM, $message, $server, true);
+    if (base64_decode($pairs['v']) !== $signature) {
+      throw new IllegalStateException('Server validation failed '.base64_encode($signature).' ('.$pairs['v'].')');
+    }
+
+    // Step 3: After having verified server signature, finalize
+    yield [
+      'saslContinue'   => 1,
+      'payload'        => '',
+      'conversationId' => $next['conversationId'],
+      '$db'            => $authsource,
+    ];
+  }
+}

--- a/src/main/php/com/mongodb/auth/ScramSHA1.class.php
+++ b/src/main/php/com/mongodb/auth/ScramSHA1.class.php
@@ -1,102 +1,23 @@
 <?php namespace com\mongodb\auth;
 
-use com\mongodb\auth\Mechanism;
-use lang\IllegalStateException;
-use util\Bytes;
-
 /**
- * Salted Challenge Response Authentication Mechanism (SCRAM) is the default
- * authentication mechanism for MongoDB.
+ * SCRAM-SHA-1 is defined in RFC 5802.
  *
  * @test  com.mongodb.unittest.ScramSHA1Test
- * @see   https://docs.mongodb.com/manual/core/security-scram/
+ * @see   https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst#scram-sha-1
  */
-class ScramSHA1 implements Mechanism {
+class ScramSHA1 extends Scram {
+  const MECHANISM= 'SCRAM-SHA-1';
   const MIN_ITERATIONS= 4096;
   const HASH_ALGORITHM= 'sha1';
 
-  private $nonce= null;
-
-  public function __construct() {
-    $this->nonce= function() { return base64_encode(random_bytes(24)); };
-  }
-
   /**
-   * Use the given function to generate nonce values
-   *
-   * @param  function(): string $callable
-   * @return self
-   */
-  public function nonce($callable) {
-    $this->nonce= $callable;
-    return $this;
-  }
-
-  private function pairs($payload) {
-    $pairs= [];
-    foreach (explode(',', $payload) as $pair) {
-      sscanf($pair, "%[^=]=%[^\r]", $key, $value);
-      $pairs[$key]= $value;
-    }
-    return $pairs;
-  }
-
-  /**
-   * Returns a conversation dialogue yielding and receiving client and server
-   * payloads, respectively.
+   * The password variable MUST be the mongodb hashed variant. The mongo hashed variant
+   * is computed as `hash = HEX(MD5(UTF8(username + ':mongo:' + plain_text_password)))`
    *
    * @return iterable
    */
   public function conversation(string $username, string $password, string $authsource) {
-
-    // Step 1: Initiate conversation with username and a random nonce
-    $gs2= 'n,,';
-    $nonce= ($this->nonce)();
-    $c1b= 'n='.$username.',r='.$nonce;
-
-    $first= yield [
-      'saslStart' => 1,
-      'mechanism' => 'SCRAM-SHA-1',
-      'payload'   => new Bytes($gs2.$c1b),
-      '$db'       => $authsource,
-    ];
-
-    $pairs= $this->pairs($first['payload']);
-    if (0 !== substr_compare($pairs['r'], $nonce, 0, strlen($nonce))) {
-      throw new IllegalStateException('Server did not extend client nonce '.$nonce.' ('.$pairs['r'].')');
-    }
-
-    if ($pairs['i'] < self::MIN_ITERATIONS) {
-      throw new IllegalStateException('Server requested less than '.self::MIN_ITERATIONS.' iterations ('.$pairs['i'].')');
-    }
-
-    // Step 2: User server-supplied nonce and hash password
-    $c2wop= 'c='.base64_encode($gs2).',r='.$pairs['r'];
-    $message= $c1b.','.$first['payload'].','.$c2wop;
-    $salted= hash_pbkdf2(self::HASH_ALGORITHM, md5($username.':mongo:'.$password), base64_decode($pairs['s']), (int)$pairs['i'], 0, true);
-    $client= hash_hmac(self::HASH_ALGORITHM, 'Client Key', $salted, true);
-    $server= hash_hmac(self::HASH_ALGORITHM, 'Server Key', $salted, true);
-    $signature= hash_hmac(self::HASH_ALGORITHM, $message, hash(self::HASH_ALGORITHM, $client, true), true);
-
-    $next= yield [
-      'saslContinue'   => 1,
-      'payload'        => new Bytes($c2wop.',p='.base64_encode($client ^ $signature)),
-      'conversationId' => $first['conversationId'],
-      '$db'            => $authsource,
-    ];
-
-    $pairs= $this->pairs($next['payload']);
-    $signature= hash_hmac(self::HASH_ALGORITHM, $message, $server, true);
-    if (base64_decode($pairs['v']) !== $signature) {
-      throw new IllegalStateException('Server validation failed '.base64_encode($signature).' ('.$pairs['v'].')');
-    }
-
-    // Step 3: After having verified server signature, finalize
-    yield [
-      'saslContinue'   => 1,
-      'payload'        => '',
-      'conversationId' => $next['conversationId'],
-      '$db'            => $authsource,
-    ];
+    return parent::conversation($username, md5($username.':mongo:'.$password), $authsource);
   }
 }

--- a/src/main/php/com/mongodb/auth/ScramSHA1.class.php
+++ b/src/main/php/com/mongodb/auth/ScramSHA1.class.php
@@ -12,8 +12,8 @@ use util\Bytes;
  * @see   https://docs.mongodb.com/manual/core/security-scram/
  */
 class ScramSHA1 implements Mechanism {
-  const MIN_ITERATIONS = 4096;
-  const HASH_ALGORITHM = 'sha1';
+  const MIN_ITERATIONS= 4096;
+  const HASH_ALGORITHM= 'sha1';
 
   private $nonce= null;
 
@@ -76,7 +76,7 @@ class ScramSHA1 implements Mechanism {
     $salted= hash_pbkdf2(self::HASH_ALGORITHM, md5($username.':mongo:'.$password), base64_decode($pairs['s']), (int)$pairs['i'], 0, true);
     $client= hash_hmac(self::HASH_ALGORITHM, 'Client Key', $salted, true);
     $server= hash_hmac(self::HASH_ALGORITHM, 'Server Key', $salted, true);
-    $signature= hash_hmac(self::HASH_ALGORITHM, $message, sha1($client, true), true);
+    $signature= hash_hmac(self::HASH_ALGORITHM, $message, hash(self::HASH_ALGORITHM, $client, true), true);
 
     $next= yield [
       'saslContinue'   => 1,
@@ -86,7 +86,7 @@ class ScramSHA1 implements Mechanism {
     ];
 
     $pairs= $this->pairs($next['payload']);
-    $signature= hash_hmac('sha1', $message, $server, true);
+    $signature= hash_hmac(self::HASH_ALGORITHM, $message, $server, true);
     if (base64_decode($pairs['v']) !== $signature) {
       throw new IllegalStateException('Server validation failed '.base64_encode($signature).' ('.$pairs['v'].')');
     }

--- a/src/main/php/com/mongodb/auth/ScramSHA256.class.php
+++ b/src/main/php/com/mongodb/auth/ScramSHA256.class.php
@@ -1,0 +1,101 @@
+<?php namespace com\mongodb\auth;
+
+use com\mongodb\auth\Mechanism;
+use lang\IllegalStateException;
+use util\Bytes;
+
+/**
+ * The MongoDB SCRAM-SHA-256 mechanism works similarly to the SCRAM-SHA-1 mechanism.
+ *
+ * @test  com.mongodb.unittest.ScramSHA256Test
+ * @see   https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst#scram-sha-256
+ */
+class ScramSHA256 implements Mechanism {
+  const MIN_ITERATIONS= 4096;
+  const HASH_ALGORITHM= 'sha256';
+
+  private $nonce= null;
+
+  public function __construct() {
+    $this->nonce= function() { return base64_encode(random_bytes(24)); };
+  }
+
+  /**
+   * Use the given function to generate nonce values
+   *
+   * @param  function(): string $callable
+   * @return self
+   */
+  public function nonce($callable) {
+    $this->nonce= $callable;
+    return $this;
+  }
+
+  private function pairs($payload) {
+    $pairs= [];
+    foreach (explode(',', $payload) as $pair) {
+      sscanf($pair, "%[^=]=%[^\r]", $key, $value);
+      $pairs[$key]= $value;
+    }
+    return $pairs;
+  }
+
+  /**
+   * Returns a conversation dialogue yielding and receiving client and server
+   * payloads, respectively.
+   *
+   * @return iterable
+   */
+  public function conversation(string $username, string $password, string $authsource) {
+
+    // Step 1: Initiate conversation with username and a random nonce
+    $gs2= 'n,,';
+    $nonce= ($this->nonce)();
+    $c1b= 'n='.$username.',r='.$nonce;
+
+    $first= yield [
+      'saslStart' => 1,
+      'mechanism' => 'SCRAM-SHA-256',
+      'payload'   => new Bytes($gs2.$c1b),
+      '$db'       => $authsource,
+    ];
+
+    $pairs= $this->pairs($first['payload']);
+    if (0 !== substr_compare($pairs['r'], $nonce, 0, strlen($nonce))) {
+      throw new IllegalStateException('Server did not extend client nonce '.$nonce.' ('.$pairs['r'].')');
+    }
+
+    if ($pairs['i'] < self::MIN_ITERATIONS) {
+      throw new IllegalStateException('Server requested less than '.self::MIN_ITERATIONS.' iterations ('.$pairs['i'].')');
+    }
+
+    // Step 2: User server-supplied nonce and hash password
+    $c2wop= 'c='.base64_encode($gs2).',r='.$pairs['r'];
+    $message= $c1b.','.$first['payload'].','.$c2wop;
+    $salted= hash_pbkdf2(self::HASH_ALGORITHM, $password, base64_decode($pairs['s']), (int)$pairs['i'], 0, true);
+    $client= hash_hmac(self::HASH_ALGORITHM, 'Client Key', $salted, true);
+    $server= hash_hmac(self::HASH_ALGORITHM, 'Server Key', $salted, true);
+    $signature= hash_hmac(self::HASH_ALGORITHM, $message, hash(self::HASH_ALGORITHM, $client, true), true);
+
+    $next= yield [
+      'saslContinue'   => 1,
+      'payload'        => new Bytes($c2wop.',p='.base64_encode($client ^ $signature)),
+      'conversationId' => $first['conversationId'],
+      '$db'            => $authsource,
+    ];
+
+    $pairs= $this->pairs($next['payload']);
+    $signature= hash_hmac(self::HASH_ALGORITHM, $message, $server, true);
+    if (base64_decode($pairs['v']) !== $signature) {
+      throw new IllegalStateException('Server validation failed '.base64_encode($signature).' ('.$pairs['v'].')');
+    }
+
+    // Step 3: After having verified server signature, finalize
+    yield [
+      'saslContinue'   => 1,
+      'payload'        => '',
+      'conversationId' => $next['conversationId'],
+      '$db'            => $authsource,
+    ];
+  }
+}

--- a/src/main/php/com/mongodb/auth/ScramSHA256.class.php
+++ b/src/main/php/com/mongodb/auth/ScramSHA256.class.php
@@ -1,101 +1,14 @@
 <?php namespace com\mongodb\auth;
 
-use com\mongodb\auth\Mechanism;
-use lang\IllegalStateException;
-use util\Bytes;
-
 /**
  * The MongoDB SCRAM-SHA-256 mechanism works similarly to the SCRAM-SHA-1 mechanism.
  *
  * @test  com.mongodb.unittest.ScramSHA256Test
  * @see   https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst#scram-sha-256
  */
-class ScramSHA256 implements Mechanism {
+class ScramSHA256 extends Scram {
+  const MECHANISM= 'SCRAM-SHA-256';
   const MIN_ITERATIONS= 4096;
   const HASH_ALGORITHM= 'sha256';
 
-  private $nonce= null;
-
-  public function __construct() {
-    $this->nonce= function() { return base64_encode(random_bytes(24)); };
-  }
-
-  /**
-   * Use the given function to generate nonce values
-   *
-   * @param  function(): string $callable
-   * @return self
-   */
-  public function nonce($callable) {
-    $this->nonce= $callable;
-    return $this;
-  }
-
-  private function pairs($payload) {
-    $pairs= [];
-    foreach (explode(',', $payload) as $pair) {
-      sscanf($pair, "%[^=]=%[^\r]", $key, $value);
-      $pairs[$key]= $value;
-    }
-    return $pairs;
-  }
-
-  /**
-   * Returns a conversation dialogue yielding and receiving client and server
-   * payloads, respectively.
-   *
-   * @return iterable
-   */
-  public function conversation(string $username, string $password, string $authsource) {
-
-    // Step 1: Initiate conversation with username and a random nonce
-    $gs2= 'n,,';
-    $nonce= ($this->nonce)();
-    $c1b= 'n='.$username.',r='.$nonce;
-
-    $first= yield [
-      'saslStart' => 1,
-      'mechanism' => 'SCRAM-SHA-256',
-      'payload'   => new Bytes($gs2.$c1b),
-      '$db'       => $authsource,
-    ];
-
-    $pairs= $this->pairs($first['payload']);
-    if (0 !== substr_compare($pairs['r'], $nonce, 0, strlen($nonce))) {
-      throw new IllegalStateException('Server did not extend client nonce '.$nonce.' ('.$pairs['r'].')');
-    }
-
-    if ($pairs['i'] < self::MIN_ITERATIONS) {
-      throw new IllegalStateException('Server requested less than '.self::MIN_ITERATIONS.' iterations ('.$pairs['i'].')');
-    }
-
-    // Step 2: User server-supplied nonce and hash password
-    $c2wop= 'c='.base64_encode($gs2).',r='.$pairs['r'];
-    $message= $c1b.','.$first['payload'].','.$c2wop;
-    $salted= hash_pbkdf2(self::HASH_ALGORITHM, $password, base64_decode($pairs['s']), (int)$pairs['i'], 0, true);
-    $client= hash_hmac(self::HASH_ALGORITHM, 'Client Key', $salted, true);
-    $server= hash_hmac(self::HASH_ALGORITHM, 'Server Key', $salted, true);
-    $signature= hash_hmac(self::HASH_ALGORITHM, $message, hash(self::HASH_ALGORITHM, $client, true), true);
-
-    $next= yield [
-      'saslContinue'   => 1,
-      'payload'        => new Bytes($c2wop.',p='.base64_encode($client ^ $signature)),
-      'conversationId' => $first['conversationId'],
-      '$db'            => $authsource,
-    ];
-
-    $pairs= $this->pairs($next['payload']);
-    $signature= hash_hmac(self::HASH_ALGORITHM, $message, $server, true);
-    if (base64_decode($pairs['v']) !== $signature) {
-      throw new IllegalStateException('Server validation failed '.base64_encode($signature).' ('.$pairs['v'].')');
-    }
-
-    // Step 3: After having verified server signature, finalize
-    yield [
-      'saslContinue'   => 1,
-      'payload'        => '',
-      'conversationId' => $next['conversationId'],
-      '$db'            => $authsource,
-    ];
-  }
 }

--- a/src/test/php/com/mongodb/unittest/ScramSHA256Test.class.php
+++ b/src/test/php/com/mongodb/unittest/ScramSHA256Test.class.php
@@ -1,0 +1,79 @@
+<?php namespace com\mongodb\unittest;
+
+use com\mongodb\auth\ScramSHA256;
+use lang\IllegalStateException;
+use test\{Assert, Expect, Test};
+use util\Bytes;
+
+/** @see https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst#scram-sha-256 */
+class ScramSHA256Test {
+  const CLIENT_NONCE = 'rOprNGfwEbeRWgbNEkqO';
+  const SERVER_NONCE = '%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0';
+  const SERVER_SALT  = 'W22ZaJ0SNY7soEsUEjb6gQ==';
+  const DATABASE     = 'test';
+
+  /** @return com.mongodb.auth.ScramSHA256 */
+  private function newFixture() {
+    return (new ScramSHA256())
+      ->nonce(function() { return self::CLIENT_NONCE; })
+      ->conversation('user', 'pencil', self::DATABASE)
+    ;
+  }
+
+  #[Test]
+  public function first_message() {
+    $auth= $this->newFixture();
+
+    Assert::equals(
+      [
+        'saslStart' => 1,
+        'mechanism' => 'SCRAM-SHA-256',
+        'payload'   => new Bytes('n,,n=user,r='.self::CLIENT_NONCE),
+        '$db'       => self::DATABASE
+      ],
+      $auth->current()
+    );
+  }
+
+  #[Test]
+  public function next_message() {
+    $auth= $this->newFixture();
+    $auth->send([
+      'conversationId' => 1,
+      'payload'        => new Bytes('r='.self::CLIENT_NONCE.self::SERVER_NONCE.',s='.self::SERVER_SALT.',i=4096'),
+    ]);
+
+    Assert::equals(
+      [
+        'saslContinue'   => 1,
+        'payload'        => new Bytes('c=biws,r='.self::CLIENT_NONCE.self::SERVER_NONCE.',p=dHzbZapWIk4jUhN+Ute9ytag9zjfMHgsqmmiz7AndVQ='),
+        'conversationId' => 1,
+        '$db'            => self::DATABASE
+      ],
+      $auth->current()
+    );
+  }
+
+  #[Test]
+  public function final_message() {
+    $auth= $this->newFixture();
+    $auth->send([
+      'conversationId' => 1,
+      'payload'        => new Bytes('r='.self::CLIENT_NONCE.self::SERVER_NONCE.',s='.self::SERVER_SALT.',i=4096'),
+    ]);
+    $auth->send([
+      'conversationId' => 1,
+      'payload'        => new Bytes('v=6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4='),
+    ]);
+
+    Assert::equals(
+      [
+        'saslContinue'   => 1,
+        'payload'        => '',
+        'conversationId' => 1,
+        '$db'            => self::DATABASE
+      ],
+      $auth->current()
+    );
+  }
+}


### PR DESCRIPTION
Implements feature suggested in #8

* * * 

A good source for was [the MongoDB specification](https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst#scram-sha-256), which states: *The MongoDB SCRAM-SHA-256 mechanism works similarly to the SCRAM-SHA-1 mechanism* [...] *Passwords are used directly for key derivation ; they MUST NOT be digested as they are in SCRAM-SHA-1*. This lead to the folllowing implementation diff:

```diff
-class ScramSHA1 implements Mechanism {
+class ScramSHA256 implements Mechanism {
   const MIN_ITERATIONS= 4096;
-  const HASH_ALGORITHM= 'sha1';
+  const HASH_ALGORITHM= 'sha256';
 
   private $nonce= null;
 
@@ -56,7 +55,7 @@
 
     $first= yield [
       'saslStart' => 1,
-      'mechanism' => 'SCRAM-SHA-1',
+      'mechanism' => 'SCRAM-SHA-256',
       'payload'   => new Bytes($gs2.$c1b),
       '$db'       => $authsource,
     ];
@@ -73,7 +72,7 @@
     // Step 2: User server-supplied nonce and hash password
     $c2wop= 'c='.base64_encode($gs2).',r='.$pairs['r'];
     $message= $c1b.','.$first['payload'].','.$c2wop;
-    $salted= hash_pbkdf2(self::HASH_ALGORITHM, md5($username.':mongo:'.$password), base64_decode($pairs['s']), (int)$pairs['i'], 0, true);
+    $salted= hash_pbkdf2(self::HASH_ALGORITHM, $password, base64_decode($pairs['s']), (int)$pairs['i'], 0, true);
     $client= hash_hmac(self::HASH_ALGORITHM, 'Client Key', $salted, true);
     $server= hash_hmac(self::HASH_ALGORITHM, 'Server Key', $salted, true);
     $signature= hash_hmac(self::HASH_ALGORITHM, $message, hash(self::HASH_ALGORITHM, $client, true), true);

```

...and eventually, to the extraction of the common functionality into the base class `Scram` in xp-forge/mongodb@cd176768ba0c4ac6ed37fc3cac07eb63550b3368