### PR TITLE
Support authentication mechanism negotiation

### DIFF
--- a/src/main/php/com/mongodb/Authentication.class.php
+++ b/src/main/php/com/mongodb/Authentication.class.php
@@ -5,7 +5,7 @@ use lang\IllegalArgumentException;
 
 /** @test com.mongodb.unittest.AuthenticationTest */
 abstract class Authentication {
-  const MECHANISMS= ['SCRAM-SHA-1', 'SCRAM-SHA-256'];
+  const MECHANISMS= ['SCRAM-SHA-256', 'SCRAM-SHA-1'];
 
   /**
    * Returns an authentication by a given mechanism name
@@ -24,10 +24,18 @@ abstract class Authentication {
    * Negotiates one of the supported authentication mechansim from a list
    * of given mechanisms.
    *
+   * If SCRAM-SHA-256 is present in the list of mechanism, then it MUST be used as
+   * the default; otherwise, SCRAM-SHA-1 MUST be used as the default, regardless of
+   * whether SCRAM-SHA-1 is in the list. If saslSupportedMechs is not present in the
+   * handshake response for mechanism negotiation, then SCRAM-SHA-1 MUST be used
+   *
+   * @see    https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst#defaults
    * @throws lang.IllegalArgumentException if none are supported
    */
   public static function negotiate(array $mechanisms): Mechanism {
-    if ($supported= array_intersect($mechanisms, self::MECHANISMS)) {
+    if (empty($mechanisms)) {
+      return self::mechanism('SCRAM-SHA-1');
+    } else if ($supported= array_intersect(self::MECHANISMS, $mechanisms)) {
       return self::mechanism(current($supported));
     }
 

--- a/src/main/php/com/mongodb/Authentication.class.php
+++ b/src/main/php/com/mongodb/Authentication.class.php
@@ -3,7 +3,9 @@
 use com\mongodb\auth\{Mechanism, ScramSHA1, ScramSHA256};
 use lang\IllegalArgumentException;
 
+/** @test com.mongodb.unittest.AuthenticationTest */
 abstract class Authentication {
+  const MECHANISMS= ['SCRAM-SHA-1', 'SCRAM-SHA-256'];
 
   /**
    * Returns an authentication by a given mechanism name
@@ -16,5 +18,22 @@ abstract class Authentication {
       case 'SCRAM-SHA-256': return new ScramSHA256();
       default: throw new IllegalArgumentException('Unknown authentication mechanism '.$name);
     }
+  }
+
+  /**
+   * Negotiates one of the supported authentication mechansim from a list
+   * of given mechanisms.
+   *
+   * @throws lang.IllegalArgumentException if none are supported
+   */
+  public static function negotiate(array $mechanisms): Mechanism {
+    if ($supported= array_intersect($mechanisms, self::MECHANISMS)) {
+      return self::mechanism(current($supported));
+    }
+
+    throw new IllegalArgumentException(sprintf(
+      'None of the authentication mechanisms %s is supported',
+      implode(', ', $mechanisms)
+    ));
   }
 }

--- a/src/main/php/com/mongodb/auth/Mechanism.class.php
+++ b/src/main/php/com/mongodb/auth/Mechanism.class.php
@@ -1,5 +1,7 @@
 <?php namespace com\mongodb\auth;
 
 interface Mechanism {
-  
+
+  /** @return string */
+  public function name();
 }

--- a/src/main/php/com/mongodb/auth/Scram.class.php
+++ b/src/main/php/com/mongodb/auth/Scram.class.php
@@ -17,6 +17,9 @@ abstract class Scram implements Mechanism {
     $this->nonce= function() { return base64_encode(random_bytes(24)); };
   }
 
+  /** @return string */
+  public function name() { return static::MECHANISM; }
+
   /**
    * Use the given function to generate nonce values
    *

--- a/src/main/php/com/mongodb/io/Connection.class.php
+++ b/src/main/php/com/mongodb/io/Connection.class.php
@@ -150,14 +150,7 @@ class Connection {
     if (null === $authSource) return;
 
     try {
-      if ($auth) {
-        // Use this explicitely specified mechanism
-      } else if ($supported= $document['saslSupportedMechs'] ?? null) {
-        $auth= Authentication::negotiate($supported);
-      } else {
-        $auth= Authentication::mechanism(Authentication::MECHANISMS[0]);
-      }
-
+      $auth ?? $auth= Authentication::negotiate($document['saslSupportedMechs'] ?? []);
       $conversation= $auth->conversation($user, $pass, $authSource);
       do {
         $result= $this->message($conversation->current(), null);

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -13,7 +13,8 @@ use util\Objects;
  * @test  com.mongodb.unittest.ReplicaSetTest
  */
 class Protocol {
-  private $options, $auth;
+  private $options;
+  protected $auth= null;
   protected $conn= [];
   public $nodes= null;
   public $readPreference;
@@ -91,10 +92,11 @@ class Protocol {
     }
 
     $this->readPreference= ['mode' => $this->options['params']['readPreference'] ?? 'primary'];
-    $this->auth= isset($this->options['user'])
-      ? Authentication::mechanism($this->options['params']['authMechanism'] ?? 'SCRAM-SHA-1')
-      : null
-    ;
+
+    // Check if an authentication mechanism was explicitely selected
+    if ($mechanism= $this->options['params']['authMechanism'] ?? null) {
+      $this->auth= Authentication::mechanism($mechanism);
+    }
   }
 
   /** @return [:var] */

--- a/src/test/php/com/mongodb/unittest/AuthenticationTest.class.php
+++ b/src/test/php/com/mongodb/unittest/AuthenticationTest.class.php
@@ -8,12 +8,52 @@ use test\{Assert, Expect, Test};
 class AuthenticationTest {
 
   #[Test]
-  public function cram_sha_1() {
+  public function sha1_is_default_mechanism() {
+    Assert::equals('SCRAM-SHA-1', Authentication::MECHANISMS[0]);
+  }
+
+  #[Test]
+  public function scram_sha_1() {
     Assert::instance(Mechanism::class, Authentication::mechanism('SCRAM-SHA-1'));
+  }
+
+  #[Test]
+  public function scram_sha_256() {
+    Assert::instance(Mechanism::class, Authentication::mechanism('SCRAM-SHA-256'));
   }
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function unknown() {
     Authentication::mechanism('unknown');
+  }
+
+  #[Test]
+  public function negotiate_sha1() {
+    Assert::equals('SCRAM-SHA-1', Authentication::negotiate(['SCRAM-SHA-1'])->name());
+  }
+
+  #[Test]
+  public function negotiate_sha1_preferred() {
+    Assert::equals('SCRAM-SHA-1', Authentication::negotiate(['SCRAM-SHA-1', 'SCRAM-SHA-256'])->name());
+  }
+
+  #[Test]
+  public function negotiate_sha256_preferred() {
+    Assert::equals('SCRAM-SHA-256', Authentication::negotiate(['SCRAM-SHA-256', 'SCRAM-SHA-1'])->name());
+  }
+
+  #[Test]
+  public function negotiate_unsupported_plain_preferred() {
+    Assert::equals('SCRAM-SHA-1', Authentication::negotiate(['PLAIN', 'SCRAM-SHA-1'])->name());
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function negotiate_none_supported() {
+    Authentication::negotiate(['PLAIN', 'AWS'])->name();
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function negotiate_empty() {
+    Authentication::negotiate([])->name();
   }
 }

--- a/src/test/php/com/mongodb/unittest/AuthenticationTest.class.php
+++ b/src/test/php/com/mongodb/unittest/AuthenticationTest.class.php
@@ -3,14 +3,9 @@
 use com\mongodb\Authentication;
 use com\mongodb\auth\Mechanism;
 use lang\IllegalArgumentException;
-use test\{Assert, Expect, Test};
+use test\{Assert, Expect, Test, Values};
 
 class AuthenticationTest {
-
-  #[Test]
-  public function sha1_is_default_mechanism() {
-    Assert::equals('SCRAM-SHA-1', Authentication::MECHANISMS[0]);
-  }
 
   #[Test]
   public function scram_sha_1() {
@@ -27,33 +22,28 @@ class AuthenticationTest {
     Authentication::mechanism('unknown');
   }
 
-  #[Test]
-  public function negotiate_sha1() {
-    Assert::equals('SCRAM-SHA-1', Authentication::negotiate(['SCRAM-SHA-1'])->name());
+  #[Test, Values([[['SCRAM-SHA-1']], [['SCRAM-SHA-256']]])]
+  public function negotiate_only_option($supplied) {
+    Assert::equals($supplied[0], Authentication::negotiate($supplied)->name());
+  }
+
+  #[Test, Values([[['SCRAM-SHA-256', 'SCRAM-SHA-1']], [['SCRAM-SHA-1', 'SCRAM-SHA-256']]])]
+  public function negotiate_sha256_is_default_if_contained($supplied) {
+    Assert::equals('SCRAM-SHA-256', Authentication::negotiate($supplied)->name());
   }
 
   #[Test]
-  public function negotiate_sha1_preferred() {
-    Assert::equals('SCRAM-SHA-1', Authentication::negotiate(['SCRAM-SHA-1', 'SCRAM-SHA-256'])->name());
-  }
-
-  #[Test]
-  public function negotiate_sha256_preferred() {
-    Assert::equals('SCRAM-SHA-256', Authentication::negotiate(['SCRAM-SHA-256', 'SCRAM-SHA-1'])->name());
-  }
-
-  #[Test]
-  public function negotiate_unsupported_plain_preferred() {
+  public function negotiate_with_unsupported_plain() {
     Assert::equals('SCRAM-SHA-1', Authentication::negotiate(['PLAIN', 'SCRAM-SHA-1'])->name());
+  }
+
+  #[Test]
+  public function negotiate_returns_sha1_if_empty() {
+    Assert::equals('SCRAM-SHA-1', Authentication::negotiate([])->name());
   }
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function negotiate_none_supported() {
     Authentication::negotiate(['PLAIN', 'AWS'])->name();
-  }
-
-  #[Test, Expect(IllegalArgumentException::class)]
-  public function negotiate_empty() {
-    Authentication::negotiate([])->name();
   }
 }


### PR DESCRIPTION
...by adding `saslSupportedMechs: <db.user>` to the *hello* command. This will return an additional field `hello.saslSupportedMechs` in its result. 

## Negotation

If an authentication mechanism is explicitely supplied via the connection string, it's used regardless of what the server answers. Otherwise, negotation tries to find the preferred authentication mechanism.

> If SCRAM-SHA-256 is present in the list of mechanism, then it MUST be used as the default; otherwise, SCRAM-SHA-1 MUST be used as the default, regardless of whether SCRAM-SHA-1 is in the list. If saslSupportedMechs is not present in the handshake response for mechanism negotiation, then SCRAM-SHA-1 MUST be used

(see https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst#defaults)

| Connection string              | Server-supplied saslSupportedMechs    | Result        |
| ------------------------------ | ------------------------------------- | ------------- |
| `?authMechanism=SCRAM-SHA-256` | (anything)                            | SCRAM-SHA-256 |
| `?authMechanism=SCRAM-SHA-1`   | (anything)                            | SCRAM-SHA-1   |
| `?authMechanism=PLAIN`         | (anything)                            | *Error* 1️⃣   |
| (not supplied)                 | [SCRAM-SHA-256, SCRAM-SHA-1]          | SCRAM-SHA-256 |
| (not supplied)                 | [SCRAM-SHA-1, SCRAM-SHA-256]          | SCRAM-SHA-256 |
| (not supplied)                 | [SCRAM-SHA-1, AWS]                    | SCRAM-SHA-1   |
| (not supplied)                 | [PLAIN, AWS]                          | *Error* 2️⃣   |
| (not supplied)                 | (empty or missing)                    | SCRAM-SHA-1   |

### Errors

1. Unsupported authentication mechanism "PLAIN"
2. None of the supplied authentication mechanisms "PLAIN", "AWS" is supported

## Real-life examples

...when adding a `var_dump()` of the returned *hello.saslSupportedMechs* key:

### Local 5.0.20 (Ubuntu)

```bash
$ xp connect.script.php mongodb://user:*********@localhost/test
array(2) {
  [0]=>
  string(11) "SCRAM-SHA-1"
  [1]=>
  string(13) "SCRAM-SHA-256"
}
```

### MongoDB Atlas

```bash
$ xp connect.script.php mongodb+srv://user:*********@example.abcdefg.mongodb.net
array(1) {
  [0]=>
  string(11) "SCRAM-SHA-1"
}
```