### PR TITLE
Refactor all methods to receive options varargs

### DIFF
--- a/src/main/php/com/mongodb/Database.class.php
+++ b/src/main/php/com/mongodb/Database.class.php
@@ -30,39 +30,39 @@ class Database implements Value {
   /**
    * Returns a list of database information objects
    *
-   * @param  ?com.mongodb.Session $session
+   * @param  com.mongodb.Options... $options
    * @return [:var][]
    * @throws com.mongodb.Error
    */
-  public function collections(Session $session= null) {
+  public function collections(Options... $options) {
     $commands= Commands::reading($this->proto);
-    $result= $commands->send($session, [
+    $result= $commands->send($options, [
       'listCollections' => (object)[],
       '$db'             => $this->name
     ]);
-    return new Cursor($commands, $session, $result['body']['cursor']);
+    return new Cursor($commands, $options, $result['body']['cursor']);
   }
 
   /**
    * Watch for changes in this database
    *
    * @param  [:var][] $pipeline
-   * @param  [:var] $options
-   * @param  ?com.mongodb.Session $session
+   * @param  [:var] $params
+   * @param  com.mongodb.Options... $options
    * @return com.mongodb.result.ChangeStream
    * @throws com.mongodb.Error
    */
-  public function watch(array $pipeline= [], array $options= [], Session $session= null): ChangeStream {
-    array_unshift($pipeline, ['$changeStream' => (object)$options]);
+  public function watch(array $pipeline= [], array $params= [], Options... $options): ChangeStream {
+    array_unshift($pipeline, ['$changeStream' => (object)$params]);
 
     $commands= Commands::reading($this->proto);
-    $result= $commands->send($session, [
+    $result= $commands->send($options, [
       'aggregate' => 1,
       'pipeline'  => $pipeline,
       'cursor'    => (object)[],
       '$db'       => $this->name,
     ]);
-    return new ChangeStream($commands, $session, $result['body']['cursor']);
+    return new ChangeStream($commands, $options, $result['body']['cursor']);
   }
 
   /** @return string */

--- a/src/main/php/com/mongodb/MongoConnection.class.php
+++ b/src/main/php/com/mongodb/MongoConnection.class.php
@@ -120,11 +120,11 @@ class MongoConnection implements Value {
    *
    * @see    https://docs.mongodb.com/manual/reference/command/listDatabases/
    * @param  ?string|com.mongodb.Regex|[:string|com.mongodb.Regex] $filter
-   * @return com.mongodb.Options... $options
+   * @param  com.mongodb.Options... $options
    * @return iterable
    * @throws com.mongodb.Error
    */
-  public function databases($filter= null, $options= null) {
+  public function databases($filter= null, Options... $options) {
     $this->proto->connect();
 
     $request= ['listDatabases' => 1, '$db' => 'admin'];

--- a/src/main/php/com/mongodb/MongoConnection.class.php
+++ b/src/main/php/com/mongodb/MongoConnection.class.php
@@ -55,18 +55,18 @@ class MongoConnection implements Value {
    * @param  string $name
    * @param  [:var] $arguments
    * @param  string $semantics one of `read` or `write`
-   * @param  ?com.mongodb.Session $session
+   * @param  com.mongodb.Options... $options
    * @return com.mongodb.result.Run
    * @throws com.mongodb.Error
    */
-  public function run($name, array $arguments= [], $semantics= 'write', Session $session= null) {
+  public function run($name, array $arguments= [], $semantics= 'write', Options... $options) {
     $this->proto->connect();
 
     $commands= Commands::using($this->proto, $semantics);
     return new Run(
       $commands,
-      $session,
-      $commands->send($session, [$name => 1] + $params + ['$db' => 'admin'])
+      $options,
+      $commands->send($options, [$name => 1] + $params + ['$db' => 'admin'])
     );
   }
 
@@ -120,11 +120,11 @@ class MongoConnection implements Value {
    *
    * @see    https://docs.mongodb.com/manual/reference/command/listDatabases/
    * @param  ?string|com.mongodb.Regex|[:string|com.mongodb.Regex] $filter
-   * @return ?com.mongodb.Session $session
+   * @return com.mongodb.Options... $options
    * @return iterable
    * @throws com.mongodb.Error
    */
-  public function databases($filter= null, $session= null) {
+  public function databases($filter= null, $options= null) {
     $this->proto->connect();
 
     $request= ['listDatabases' => 1, '$db' => 'admin'];
@@ -136,7 +136,7 @@ class MongoConnection implements Value {
       $request+= ['filter' => ['name' => $filter]];
     }
 
-    foreach ($this->proto->read($session, $request)['body']['databases'] as $d) {
+    foreach ($this->proto->read($options, $request)['body']['databases'] as $d) {
       yield $d['name'] => [
         'name'       => $d['name'],
         'sizeOnDisk' => $d['sizeOnDisk'] instanceof Int64 ? $d['sizeOnDisk'] : new Int64($d['sizeOnDisk']),
@@ -150,24 +150,24 @@ class MongoConnection implements Value {
    * Watch for changes in all databases.
    *
    * @param  [:var][] $pipeline
-   * @param  [:var] $options
-   * @param  ?com.mongodb.Session $session
+   * @param  [:var] $params
+   * @param  com.mongodb.Options... $options
    * @return com.mongodb.result.ChangeStream
    * @throws com.mongodb.Error
    */
-  public function watch(array $pipeline= [], array $options= [], Session $session= null): ChangeStream {
+  public function watch(array $pipeline= [], array $params= [], Options... $options): ChangeStream {
     $this->proto->connect();
 
-    array_unshift($pipeline, ['$changeStream' => ['allChangesForCluster' => true] + $options]);
+    array_unshift($pipeline, ['$changeStream' => ['allChangesForCluster' => true] + $params]);
 
     $commands= Commands::reading($this->proto);
-    $result= $commands->send($session, [
+    $result= $commands->send($options, [
       'aggregate' => 1,
       'pipeline'  => $pipeline,
       'cursor'    => (object)[],
       '$db'       => 'admin',
     ]);
-    return new ChangeStream($commands, $session, $result['body']['cursor']);
+    return new ChangeStream($commands, $options, $result['body']['cursor']);
   }
 
   /** @return string */

--- a/src/main/php/com/mongodb/Options.class.php
+++ b/src/main/php/com/mongodb/Options.class.php
@@ -4,8 +4,19 @@ class Options {
   private $pairs;
 
   /** @param [:var] */
-  public function __construct(array $pairs) {
+  public function __construct(array $pairs= []) {
     $this->pairs= $pairs;
+  }
+
+  /**
+   * Sets read preference
+   *
+   * @param  string $mode
+   * @return self
+   */
+  public function readPreference($mode) {
+    $this->pairs['$readPreference']= ['mode' => $mode];
+    return $this;
   }
 
   /**

--- a/src/main/php/com/mongodb/Options.class.php
+++ b/src/main/php/com/mongodb/Options.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb;
 
 class Options {
-  private $pairs;
+  protected $pairs;
 
   /** @param [:var] */
   public function __construct(array $pairs= []) {

--- a/src/main/php/com/mongodb/Options.class.php
+++ b/src/main/php/com/mongodb/Options.class.php
@@ -1,0 +1,20 @@
+<?php namespace com\mongodb;
+
+class Options {
+  private $pairs;
+
+  /** @param [:var] */
+  public function __construct(array $pairs) {
+    $this->pairs= $pairs;
+  }
+
+  /**
+   * Returns fields to be sent along with the command. Used by Protocol class.
+   *
+   * @param  com.mongodb.io.Protocol
+   * @return [:var]
+   */
+  public function send($proto) {
+    return $this->pairs;
+  }
+}

--- a/src/main/php/com/mongodb/Session.class.php
+++ b/src/main/php/com/mongodb/Session.class.php
@@ -80,7 +80,7 @@ class Session extends Options implements Value, Closeable {
 
     try {
       if (!isset($this->transaction['context']['startTransaction'])) {
-        $this->proto->write($this, ['commitTransaction' => 1, '$db' => 'admin'] + $this->transaction['t'] + $this->transaction['context']);
+        $this->proto->write([$this], ['commitTransaction' => 1, '$db' => 'admin'] + $this->transaction['t'] + $this->transaction['context']);
       }
     } finally {
       unset($this->transaction['context']);
@@ -101,7 +101,7 @@ class Session extends Options implements Value, Closeable {
 
     try {
       if (!isset($this->transaction['context']['startTransaction'])) {
-        $this->proto->write($this, ['abortTransaction' => 1, '$db' => 'admin'] + $this->transaction['context']);
+        $this->proto->write([$this], ['abortTransaction' => 1, '$db' => 'admin'] + $this->transaction['context']);
       }
     } finally {
       unset($this->transaction['context']);
@@ -139,7 +139,7 @@ class Session extends Options implements Value, Closeable {
     // Should there be an active running transaction, abort it.
     if (isset($this->transaction['context'])) {
       try {
-        $this->proto->write($this, ['abortTransaction' => 1, '$db' => 'admin'] + $this->transaction['context']);
+        $this->proto->write([$this], ['abortTransaction' => 1, '$db' => 'admin'] + $this->transaction['context']);
       } catch (Throwable $ignored) {
         // NOOP
       }
@@ -149,7 +149,7 @@ class Session extends Options implements Value, Closeable {
     // Fire and forget: If the user has no session that match, the endSessions call has
     // no effect, see https://docs.mongodb.com/manual/reference/command/endSessions/
     try {
-      $this->proto->write($this, ['endSessions' => [['id' => $this->id]], '$db' => 'admin']);
+      $this->proto->write([$this], ['endSessions' => [['id' => $this->id]], '$db' => 'admin']);
     } catch (Throwable $ignored) {
       // NOOP
     }

--- a/src/main/php/com/mongodb/Session.class.php
+++ b/src/main/php/com/mongodb/Session.class.php
@@ -13,7 +13,7 @@ use util\{UUID, Objects};
  * @test  com.mongodb.unittest.SessionTest
  * @test  com.mongodb.unittest.SessionsTest
  */
-class Session implements Value, Closeable {
+class Session extends Options implements Value, Closeable {
   private $proto, $id;
   private $closed= false;
   private $transaction= ['n' => 0];

--- a/src/main/php/com/mongodb/Session.class.php
+++ b/src/main/php/com/mongodb/Session.class.php
@@ -25,6 +25,7 @@ class Session extends Options implements Value, Closeable {
    * @param  string|util.UUID $id
    */
   public function __construct(Protocol $proto, $id) {
+    parent::__construct([]);
     $this->proto= $proto;
     $this->id= $id instanceof UUID ? $id : new UUID($id);
   }
@@ -124,7 +125,7 @@ class Session extends Options implements Value, Closeable {
     // add the lsid, txnNumber, startTransaction, and autocommit fields. When 
     // constructing any other command within a transaction, drivers MUST add
     // the lsid, txnNumber, and autocommit fields.
-    $fields= ['lsid' => ['id' => $this->id]];
+    $fields= ['lsid' => ['id' => $this->id]] + $this->pairs;
     if (isset($this->transaction['context'])) {
       $fields+= $this->transaction['context'];
       unset($this->transaction['context']['startTransaction']);

--- a/src/main/php/com/mongodb/io/Commands.class.php
+++ b/src/main/php/com/mongodb/io/Commands.class.php
@@ -23,7 +23,7 @@ class Commands {
   /** Creates an instance for reading */
   public static function reading(Protocol $proto): self {
     return new self($proto, $proto->establish(
-      $proto->candidates($proto->readPreference['mode']),
+      $proto->candidates($proto->readPreference),
       'reading with '.$proto->readPreference['mode']
     ));
   }

--- a/src/main/php/com/mongodb/io/Commands.class.php
+++ b/src/main/php/com/mongodb/io/Commands.class.php
@@ -54,13 +54,15 @@ class Commands {
   /**
    * Sends a message
    *
-   * @param  ?com.mongodb.Session $session
+   * @param  com.mongodb.Options $options
    * @param  [:var] $sections
    * @return var
    * @throws com.mongodb.Error
    */
-  public function send($session, $sections) {
-    $session && $sections+= $session->send($this->proto);
+  public function send($options, $sections) {
+    foreach ($options as $option) {
+      $sections+= $option->send($this->proto);
+    }
     return $this->conn->message($sections, $this->proto->readPreference);
   }
 }

--- a/src/main/php/com/mongodb/io/Commands.class.php
+++ b/src/main/php/com/mongodb/io/Commands.class.php
@@ -54,7 +54,7 @@ class Commands {
   /**
    * Sends a message
    *
-   * @param  com.mongodb.Options $options
+   * @param  com.mongodb.Options[] $options
    * @param  [:var] $sections
    * @return var
    * @throws com.mongodb.Error

--- a/src/main/php/com/mongodb/io/Commands.class.php
+++ b/src/main/php/com/mongodb/io/Commands.class.php
@@ -63,6 +63,8 @@ class Commands {
     foreach ($options as $option) {
       $sections+= $option->send($this->proto);
     }
-    return $this->conn->message($sections, $this->proto->readPreference);
+
+    $rp= $section['$readPreference'] ?? $this->proto->readPreference;
+    return $this->conn->message($sections, $rp);
   }
 }

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -227,10 +227,10 @@ class Protocol {
     foreach ($options as $option) {
       $sections+= $option->send($this);
     }
-    $rp= $sections['$readPreference'] ?? $this->readPreference['mode'];
 
-    return $this->establish($this->candidates($rp), 'reading with '.$rp)
-      ->message($sections, $this->readPreference)
+    $rp= $sections['$readPreference'] ?? $this->readPreference;
+    return $this->establish($this->candidates($rp['mode']), 'reading with '.$rp['mode'])
+      ->message($sections, $rp)
     ;
   }
 
@@ -246,10 +246,10 @@ class Protocol {
     foreach ($options as $option) {
       $sections+= $option->send($this);
     }
-    $rp= $sections['$readPreference'] ?? $this->readPreference['mode'];
 
+    $rp= $sections['$readPreference'] ?? $this->readPreference;
     return $this->establish([$this->nodes['primary']], 'writing')
-      ->message($sections, $this->readPreference)
+      ->message($sections, $rp)
     ;
   }
 

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -141,20 +141,20 @@ class Protocol {
    *
    * @see    https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#read-preference
    * @see    https://docs.mongodb.com/manual/core/read-preference-mechanics/
-   * @param  string $rp
+   * @param  [:var] $rp
    * @return string[]
    * @throws lang.IllegalArgumentException
    */
   public function candidates($rp) {
-    if ('primary' === $rp) {
+    if ('primary' === $rp['mode']) {
       return [$this->nodes['primary']];
-    } else if ('secondary' === $rp) {
+    } else if ('secondary' === $rp['mode']) {
       return $this->nodes['secondary'];
-    } else if ('primaryPreferred' === $rp) {
+    } else if ('primaryPreferred' === $rp['mode']) {
       return array_merge([$this->nodes['primary']], $this->nodes['secondary']);
-    } else if ('secondaryPreferred' === $rp) {
+    } else if ('secondaryPreferred' === $rp['mode']) {
       return array_merge($this->nodes['secondary'], [$this->nodes['primary']]);
-    } else if ('nearest' === $rp) {  // Prefer to stay on already open connections
+    } else if ('nearest' === $rp['mode']) {  // Prefer to stay on already open connections
       $connected= null;
       foreach ($this->conn as $id => $conn) {
         if (null === $conn->server) continue;
@@ -229,7 +229,7 @@ class Protocol {
     }
 
     $rp= $sections['$readPreference'] ?? $this->readPreference;
-    return $this->establish($this->candidates($rp['mode']), 'reading with '.$rp['mode'])
+    return $this->establish($this->candidates($rp), 'reading with '.$rp['mode'])
       ->message($sections, $rp)
     ;
   }

--- a/src/main/php/com/mongodb/result/Cursor.class.php
+++ b/src/main/php/com/mongodb/result/Cursor.class.php
@@ -7,18 +7,18 @@ use util\Objects;
 
 /** @test com.mongodb.unittest.result.CursorTest */
 class Cursor implements Value, IteratorAggregate {
-  protected $commands, $session, $current;
+  protected $commands, $options, $current;
 
   /**
    * Creates a new cursor
    *
    * @param  com.mongodb.io.Commands $commands
-   * @param  ?com.mongodb.Session $session
+   * @param  com.mongodb.Options[] $options
    * @param  [:var] $current
    */
-  public function __construct($commands, $session, $current) {
+  public function __construct($commands, $options, $current) {
     $this->commands= $commands;
-    $this->session= $session;
+    $this->options= $options;
     $this->current= $current;
   }
 
@@ -34,7 +34,7 @@ class Cursor implements Value, IteratorAggregate {
     // Fetch subsequent batches
     sscanf($this->current['ns'], "%[^.].%[^\r]", $database, $collection);
     while ($this->current['id']->number() > 0) {
-      $result= $this->commands->send($this->session, [
+      $result= $this->commands->send($this->options, [
         'getMore'    => $this->current['id'],
         'collection' => $collection,
         '$db'        => $database,
@@ -93,7 +93,7 @@ class Cursor implements Value, IteratorAggregate {
     if (0 === $this->current['id']->number()) return;
 
     sscanf($this->current['ns'], "%[^.].%[^\r]", $database, $collection);
-    $this->commands->send($this->session, [
+    $this->commands->send($this->options, [
       'killCursors' => $collection,
       'cursors'     => [$this->current['id']],
       '$db'         => $database,

--- a/src/main/php/com/mongodb/result/Run.class.php
+++ b/src/main/php/com/mongodb/result/Run.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb\result;
 
 class Run extends Result {
-  private $commands, $session;
+  private $commands, $options;
   private $cursor= null;
 
   /**
@@ -9,12 +9,12 @@ class Run extends Result {
    *
    * @see    com.mongodb.Collection::run()
    * @param  com.mongodb.io.Commands $commands
-   * @param  ?com.mongodb.Session $session
+   * @param  com.mongodb.Options[] $options
    * @param  [:var] $result
    */
-  public function __construct($commands, $session, $result) {
+  public function __construct($commands, $options, $result) {
     $this->commands= $commands;
-    $this->session= $session;
+    $this->options= $options;
     parent::__construct($result);
   }
 
@@ -32,7 +32,7 @@ class Run extends Result {
    */
   public function cursor() {
     return $this->cursor ?? (isset($this->result['body']['cursor'])
-      ? $this->cursor= new Cursor($this->commands, $this->session, $this->result['body']['cursor'])
+      ? $this->cursor= new Cursor($this->commands, $this->options, $this->result['body']['cursor'])
       : null
     );
   }
@@ -48,7 +48,7 @@ class Run extends Result {
       // If cursor was previously fetched using cursor(), any remaining elements will
       // be discarded by that Cursor instance. Otherwise, do this ourselves.
       sscanf($this->result['body']['cursor']['ns'], "%[^.].%[^\r]", $database, $collection);
-      $this->commands->send($this->session, [
+      $this->commands->send($this->options, [
         'killCursors' => $collection,
         'cursors'     => [$this->result['body']['cursor']['id']],
         '$db'         => $database,

--- a/src/test/php/com/mongodb/unittest/CollectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionTest.class.php
@@ -306,7 +306,7 @@ class CollectionTest {
     $proto= $this->protocol($replies, 'primary')->connect();
 
     $coll= new Collection($proto, 'test', 'tests');
-    $coll->find([], new Options(['$readPreference' => ['mode' => 'secondaryPreferred']]));
+    $coll->find([], (new Options())->readPreference('secondaryPreferred'));
 
     $find= [
       'find'            => 'tests',

--- a/src/test/php/com/mongodb/unittest/CollectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionTest.class.php
@@ -299,4 +299,21 @@ class CollectionTest {
     ];
     Assert::equals($find, $proto->connections()[self::$PRIMARY]->command(-1));
   }
+
+  #[Test]
+  public function find_with_read_preference() {
+    $replies= [self::$PRIMARY => [$this->hello(self::$PRIMARY), $this->cursor([])]];
+    $proto= $this->protocol($replies, 'primary')->connect();
+
+    $coll= new Collection($proto, 'test', 'tests');
+    $coll->find([], new Options(['$readPreference' => ['mode' => 'secondaryPreferred']]));
+
+    $find= [
+      'find'            => 'tests',
+      'filter'          => (object)[],
+      '$db'             => 'test',
+      '$readPreference' => ['mode' => 'secondaryPreferred']
+    ];
+    Assert::equals($find, $proto->connections()[self::$PRIMARY]->command(-1));
+  }
 }

--- a/src/test/php/com/mongodb/unittest/CollectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionTest.class.php
@@ -1,10 +1,13 @@
 <?php namespace com\mongodb\unittest;
 
-use com\mongodb\{Collection, Document, Int64, ObjectId};
-use test\{Assert, Test, Values};
+use com\mongodb\{Collection, Document, Int64, ObjectId, Options, Session};
+use test\{Assert, Before, Test, Values};
+use util\UUID;
 
 class CollectionTest {
   use WireTesting;
+
+  private $sessionId;
 
   /** @return iterable */
   private function documents() {
@@ -22,6 +25,11 @@ class CollectionTest {
     $responses= [$this->hello(self::$PRIMARY), ['body' => ['ok' => 1] + $response]];
     $protocol= $this->protocol([self::$PRIMARY => $responses], 'primary');
     return new Collection($protocol->connect(), 'testing', 'tests');
+  }
+
+  #[Before]
+  public function sessionId() {
+    $this->sessionId= new UUID('5f375bfe-af78-4af8-bb03-5d441a66a5fb');
   }
 
   #[Test]
@@ -249,5 +257,46 @@ class CollectionTest {
       'com.mongodb.Collection<testing.tests@mongodb://'.self::$PRIMARY.'>',
       $this->newFixture([])->toString()
     );
+  }
+
+  #[Test]
+  public function find_with_session() {
+    $replies= [self::$PRIMARY => [$this->hello(self::$PRIMARY), $this->cursor([]), $this->ok()]];
+    $proto= $this->protocol($replies, 'primary')->connect();
+
+    $session= new Session($proto, $this->sessionId);
+    try {
+      $coll= new Collection($proto, 'test', 'tests');
+      $coll->find([], $session);
+    } finally {
+      $session->close();
+    }
+
+    $find= [
+      'find'            => 'tests',
+      'filter'          => (object)[],
+      '$db'             => 'test',
+      'lsid'            => ['id' => $this->sessionId],
+      '$readPreference' => ['mode' => 'primary']
+    ];
+    Assert::equals($find, $proto->connections()[self::$PRIMARY]->command(-2));
+  }
+
+  #[Test]
+  public function find_with_options() {
+    $replies= [self::$PRIMARY => [$this->hello(self::$PRIMARY), $this->cursor([])]];
+    $proto= $this->protocol($replies, 'primary')->connect();
+
+    $coll= new Collection($proto, 'test', 'tests');
+    $coll->find([], new Options(['sort' => ['name' => -1]]));
+
+    $find= [
+      'find'            => 'tests',
+      'filter'          => (object)[],
+      '$db'             => 'test',
+      'sort'            => ['name' => -1],
+      '$readPreference' => ['mode' => 'primary']
+    ];
+    Assert::equals($find, $proto->connections()[self::$PRIMARY]->command(-1));
   }
 }

--- a/src/test/php/com/mongodb/unittest/ReplicaSetTest.class.php
+++ b/src/test/php/com/mongodb/unittest/ReplicaSetTest.class.php
@@ -58,7 +58,7 @@ class ReplicaSetTest {
       self::$SECONDARY2 => [],
     ];
     $fixture= $this->protocol($replicaSet, 'secondaryPreferred')->connect();
-    $fixture->read(null, [/* anything */]);
+    $fixture->read([], [/* anything */]);
 
     Assert::equals(
       [self::$PRIMARY => TestingConnection::RSPrimary, self::$SECONDARY1 => null, self::$SECONDARY2 => null],
@@ -84,7 +84,7 @@ class ReplicaSetTest {
       self::$SECONDARY2 => [],
     ];
     $fixture= $this->protocol($replicaSet, $readPreference)->connect();
-    $fixture->read(null, [/* anything */]);
+    $fixture->read([], [/* anything */]);
 
     Assert::equals(
       [self::$PRIMARY => TestingConnection::RSPrimary, self::$SECONDARY1 => TestingConnection::RSSecondary, self::$SECONDARY2 => null],
@@ -100,7 +100,7 @@ class ReplicaSetTest {
       self::$SECONDARY2 => [$this->hello(self::$SECONDARY2), $this->ok()],
     ];
     $fixture= $this->protocol($replicaSet, $readPreference)->connect();
-    $fixture->read(null, [/* anything */]);
+    $fixture->read([], [/* anything */]);
 
     Assert::equals(
       [self::$PRIMARY => TestingConnection::RSPrimary, self::$SECONDARY1 => null, self::$SECONDARY2 => TestingConnection::RSSecondary],
@@ -116,7 +116,7 @@ class ReplicaSetTest {
       self::$SECONDARY2 => [$this->hello(self::$SECONDARY2), $this->ok()],
     ];
     $fixture= $this->protocol($replicaSet, $readPreference)->connect();
-    $fixture->read(null, [/* anything */]);
+    $fixture->read([], [/* anything */]);
 
     $connected= $this->connected($fixture);
     Assert::equals(TestingConnection::RSSecondary, $connected[self::$SECONDARY1] ?? $connected[self::$SECONDARY2]);
@@ -130,7 +130,7 @@ class ReplicaSetTest {
       self::$SECONDARY2 => [$this->hello(self::$SECONDARY2), $this->ok()],
     ];
     $fixture= $this->protocol($replicaSet, $readPreference)->connect();
-    $fixture->read(null, [/* anything */]);
+    $fixture->read([], [/* anything */]);
 
     Assert::equals(
       [self::$PRIMARY => TestingConnection::RSPrimary, self::$SECONDARY1 => null, self::$SECONDARY2 => TestingConnection::RSSecondary],
@@ -145,7 +145,7 @@ class ReplicaSetTest {
       self::$SECONDARY1  => [$this->hello(self::$SECONDARY1), $this->cursor([['n' => 44]])],
       self::$SECONDARY2  => [$this->hello(self::$SECONDARY1), $this->cursor([['n' => 44]])],
     ];
-    $response= $this->protocol($replicaSet, $readPreference)->connect()->read(null, [
+    $response= $this->protocol($replicaSet, $readPreference)->connect()->read([], [
       'aggregate' => 'test.entries',
       'pipeline'  => ['$count' => 'n'],
       'cursor'    => (object)[],
@@ -179,7 +179,7 @@ class ReplicaSetTest {
       ]],
       self::$SECONDARY2  => [],
     ];
-    $response= $this->protocol($replicaSet)->connect()->write(null, [
+    $response= $this->protocol($replicaSet)->connect()->write([], [
       'delete'    => 'test',
       'deletes'   => [['q' => ['_id' => new ObjectId('622b53218e7205b37f8f8774')], 'limit' => 1]],
       'ordered'   => true,
@@ -197,7 +197,7 @@ class ReplicaSetTest {
       self::$SECONDARY2 => [],
     ];
     $fixture= $this->protocol($replicaSet, 'secondary')->connect();
-    $fixture->read(null, [/* anything */]);
+    $fixture->read([], [/* anything */]);
   }
 
   #[Test, Expect(class: NoSuitableCandidate::class, message: '/No suitable candidate eligible for writing/')]
@@ -208,7 +208,7 @@ class ReplicaSetTest {
       self::$SECONDARY2 => [$this->hello(self::$SECONDARY2)],
     ];
     $fixture= $this->protocol($replicaSet, 'primary')->connect();
-    $fixture->write(null, [/* anything */]);
+    $fixture->write([], [/* anything */]);
   }
 
   #[Test]
@@ -222,7 +222,7 @@ class ReplicaSetTest {
     $fixture->socketCheckInterval= 0;
 
     // This will connect and then read from secondary #1 successfully.
-    $fixture->read(null, [
+    $fixture->read([], [
       'aggregate' => 'test.entries',
       'pipeline'  => ['$count' => 'n'],
       'cursor'    => (object)[],
@@ -231,7 +231,7 @@ class ReplicaSetTest {
 
     // This will first run into an error while pinging secondary #1, closing the
     // connection, subsequently reconnecting and then fetching the new count.
-    $response= $fixture->read(null, [
+    $response= $fixture->read([], [
       'aggregate' => 'test.entries',
       'pipeline'  => ['$count' => 'n'],
       'cursor'    => (object)[],
@@ -260,7 +260,7 @@ class ReplicaSetTest {
     $fixture= $this->protocol($replicaSet, 'primary')->connect();
 
     Assert::throws(Error::class, function() use($fixture) {
-      $fixture->read(null, [/* anything */]);
+      $fixture->read([], [/* anything */]);
     });
     Assert::equals(
       [self::$PRIMARY => TestingConnection::RSPrimary, self::$SECONDARY1 => null, self::$SECONDARY2 => null],
@@ -283,7 +283,7 @@ class ReplicaSetTest {
     }
 
     // Calling read() will reconnect
-    $response= $protocol->read(null, [
+    $response= $protocol->read([], [
       'aggregate' => 'test.entries',
       'pipeline'  => ['$count' => 'n'],
       'cursor'    => (object)[],

--- a/src/test/php/com/mongodb/unittest/SessionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/SessionTest.class.php
@@ -15,7 +15,7 @@ class SessionTest {
   public function protocol() {
     $this->protocol= new class('mongo://localhost') extends Protocol {
       public $sent= [];
-      public function write($session, $sections) { return ['ok' => 1]; }
+      public function write(array $options, $sections) { return ['ok' => 1]; }
     };
   }
 
@@ -83,7 +83,7 @@ class SessionTest {
   #[Test]
   public function closes_even_when_endSessions_raises_an_exception() {
     $protocol= new class('mongo://localhost') extends Protocol {
-      public function write($session, $sections) {
+      public function write(array $options, $sections) {
         throw new Error(6100, 'MorePower', 'Closing failed');
       }
     };

--- a/src/test/php/com/mongodb/unittest/SessionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/SessionTest.class.php
@@ -122,4 +122,24 @@ class SessionTest {
   public function send_with_different_protocol() {
     (new Session($this->protocol, self::ID))->send(new Protocol('mongo://test'));
   }
+
+  #[Test]
+  public function send() {
+    $id= new UUID(self::ID);
+    $session= new Session($this->protocol, $id);
+
+    Assert::equals(['lsid' => ['id' => $id]], $session->send($this->protocol));
+  }
+
+  #[Test]
+  public function send_read_preference() {
+    $id= new UUID(self::ID);
+    $session= new Session($this->protocol, $id);
+    $session->readPreference('secondary');
+
+    Assert::equals(
+      ['lsid' => ['id' => $id], '$readPreference' => ['mode' => 'secondary']],
+      $session->send($this->protocol)
+    );
+  }
 }

--- a/src/test/php/com/mongodb/unittest/SessionsTest.class.php
+++ b/src/test/php/com/mongodb/unittest/SessionsTest.class.php
@@ -37,8 +37,8 @@ class SessionsTest {
   private function transaction($replies, $command, $options= null) {
     return $this->session($replies, function($proto, $session) use($command, $options) {
       $transaction= $session->transaction($options);
-      $proto->write($transaction, $command);
-      $proto->write($transaction, $command);
+      $proto->write([$transaction], $command);
+      $proto->write([$transaction], $command);
       $transaction->commit();
     });
   }
@@ -53,7 +53,7 @@ class SessionsTest {
     $replies= [self::$PRIMARY => [$this->hello(self::$PRIMARY), $this->cursor([['n' => 45]]), $this->ok()]];
     $count= ['count' => 'entries', '$db' => 'test'];
     $fixture= $this->session($replies, function($proto, $session) use($count) {
-      $proto->read($session, $count);
+      $proto->read([$session], $count);
     });
 
     $conn= $fixture->connections()[self::$PRIMARY];

--- a/src/test/php/com/mongodb/unittest/SessionsTest.class.php
+++ b/src/test/php/com/mongodb/unittest/SessionsTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\mongodb\unittest;
 
-use com\mongodb\{Int64, Session};
+use com\mongodb\{Int64, Session, Collection};
 use test\{Assert, Before, Test};
 use util\UUID;
 


### PR DESCRIPTION
Currently, there is no way to pass additional options to *find* , which has a ton of them, see https://www.mongodb.com/docs/manual/reference/command/find/. Instead of extending the `find()` method (and others) to accept tons of optional arguments after the already-optional *session*, this pull request create a `com.mongodb.Options` base class from which *Session* inherits, and uses varargs.

The following change is applied consistently to all connection, database and collection methods:

```diff
- * @param  ?com.mongodb.Session $session
+ * @param  com.mongodb.Options... $options
```

⚠️ Although code using the API will only have to be changed if it uses the internal protocol, connection and result APIs directly, this pull request **is** a BC break - and merging this PR will thus result in a major version release (2.0.0. at the time of writing).

## Passing options to find

```php
use com\mongodb\{Collection, Options};

$coll= $conn->collection('test', 'tests');
$coll->find([], new Options(['sort' => ['name' => -1]]));
```

## Read preference per command

```php
use com\mongodb\{Collection, Options};

$coll= $conn->collection('test', 'tests');

// Overwrite global read preference
$coll->find([], (new Options())->readPreference('secondaryPreferred'));
```

## Sessions

```php
use com\mongodb\{Collection, Options, Session};

// Use sessions, unchanged from before as com.mongodb.Session extends com.mongodb.Options
$session= $conn->session();
$coll->find([], $session);
$session->close();

// Combine both, order can be options, session or session, options.
$session= $conn->session();
$coll->find([], new Options(['sort' => ['name' => -1]]), $session);
$session->close();
```

## See also

* https://github.com/xp-forge/mongodb/issues/11#issuecomment-1073279950