### PR TITLE
Implement read and write concerns

### DIFF
--- a/src/main/php/com/mongodb/Options.class.php
+++ b/src/main/php/com/mongodb/Options.class.php
@@ -36,10 +36,14 @@ class Options {
    *
    * @see    https://www.mongodb.com/docs/manual/reference/write-concern/
    * @param  string|int $w
+   * @param  ?int $wtimeout
+   * @param  ?bool $journal
    * @return self
    */
-  public function writeConcern($w) {
+  public function writeConcern($w, $wtimeout= null, $journal= null) {
     $this->pairs['writeConcern']= ['w' => $w];
+    null === $wtimeout || $this->pairs['writeConcern']['wtimeout']= (int)$wtimeout;
+    null === $journal || $this->pairs['writeConcern']['j']= (bool)$journal;
     return $this;
   }
 

--- a/src/main/php/com/mongodb/Options.class.php
+++ b/src/main/php/com/mongodb/Options.class.php
@@ -20,6 +20,30 @@ class Options {
   }
 
   /**
+   * Sets read concern (the read isolation level)
+   *
+   * @see    https://www.mongodb.com/docs/manual/reference/read-concern/
+   * @param  string $level
+   * @return self
+   */
+  public function readConcern($level) {
+    $this->pairs['readConcern']= ['level' => $level];
+    return $this;
+  }
+
+  /**
+   * Sets write concern (the write acknowledgment)
+   *
+   * @see    https://www.mongodb.com/docs/manual/reference/write-concern/
+   * @param  string|int $w
+   * @return self
+   */
+  public function writeConcern($w) {
+    $this->pairs['writeConcern']= ['w' => $w];
+    return $this;
+  }
+
+  /**
    * Returns fields to be sent along with the command. Used by Protocol class.
    *
    * @param  com.mongodb.io.Protocol

--- a/src/test/php/com/mongodb/unittest/OptionsTest.class.php
+++ b/src/test/php/com/mongodb/unittest/OptionsTest.class.php
@@ -29,4 +29,36 @@ class OptionsTest {
       (new Options())->readPreference('secondary')->send($this->protocol)
     );
   }
+
+  #[Test, Values(['local', 'available'])]
+  public function read_concern($level) {
+    Assert::equals(
+      ['readConcern' => ['level' => $level]],
+      (new Options())->readConcern($level)->send($this->protocol)
+    );
+  }
+
+  #[Test, Values(['majority', 1])]
+  public function write_concern($w) {
+    Assert::equals(
+      ['writeConcern' => ['w' => $w]],
+      (new Options())->writeConcern($w)->send($this->protocol)
+    );
+  }
+
+  #[Test]
+  public function write_concern_with_timeout() {
+    Assert::equals(
+      ['writeConcern' => ['w' => 2, 'wtimeout' => 10000]],
+      (new Options())->writeConcern(2, 10000)->send($this->protocol)
+    );
+  }
+
+  #[Test]
+  public function write_concern_with_journal() {
+    Assert::equals(
+      ['writeConcern' => ['w' => 2, 'j' => true]],
+      (new Options())->writeConcern(2, null, true)->send($this->protocol)
+    );
+  }
 }


### PR DESCRIPTION
This pull request adds `readConcern()` and `writeConcern()` method to the `Options` class. 

ℹ️ This pull request does not include concern inheritance (*connection -> database -> collection (-> session) -> command*) as described in https://www.mongodb.com/docs/manual/reference/mongodb-defaults/. This requires us to know which command to pass *readConcern* to and which ones support *writeConcern*, as doing otherwise results in errors, see https://github.com/xp-forge/mongodb/issues/11#issuecomment-1684912439.

## Read concerns

```php
use com\mongodb\{Collection, Options};

$coll= $conn->collection('test', 'tests');
$coll->find([], (new Options())->readConcern('local'));
```

## Write concerns

```php
use com\mongodb\{Collection, Options, ObjectId};

$coll= $conn->collection('test', 'tests');
$coll->update(new ObjectId('...'), $operations, (new Options())->writeConcern('majority'));
```

## See also

* #11
* https://www.mongodb.com/docs/manual/reference/read-concern/
* https://www.mongodb.com/docs/manual/reference/write-concern/