### PR TITLE
Retry "Exception: not primary" when writing

### DIFF
--- a/src/main/php/com/mongodb/Error.class.php
+++ b/src/main/php/com/mongodb/Error.class.php
@@ -9,6 +9,8 @@ use lang\XPException;
  * @see   https://raw.githubusercontent.com/mongodb/mongo/master/src/mongo/base/error_codes.yml
  */
 class Error extends XPException {
+  const NOT_PRIMARY= [10107 => 1, 11602 => 1, 13435 => 1, 13436 => 1];
+
   private $kind;
   
   /**

--- a/src/main/php/com/mongodb/io/Commands.class.php
+++ b/src/main/php/com/mongodb/io/Commands.class.php
@@ -10,7 +10,7 @@ use com\mongodb\Error;
  */
 class Commands {
   private $proto, $conn;
-  private $retry= 1;
+  private $retry= true;
 
   /**
    * Creates an instance using a protocol and connection instance.
@@ -69,20 +69,22 @@ class Commands {
 
     $rp= $section['$readPreference'] ?? $this->proto->readPreference;
 
-    // Only retry the very first command in this sequence!
-    retry: $r= $this->conn->send(Connection::OP_MSG, "\x00\x00\x00\x00\x00", $sections, $rp);
-    if (1 === (int)$r['body']['ok']) {
-      $this->retry--;
-      return $r;
-    }
+    // Only retry the very first command once in this sequence!
+    try {
+      retry: $r= $this->conn->send(Connection::OP_MSG, "\x00\x00\x00\x00\x00", $sections, $rp);
+      if (1 === (int)$r['body']['ok']) return $r;
 
-    // Retry "NotWritablePrimary" errors, replacing the connection
-    if ($this->retry-- && isset(Error::NOT_PRIMARY[$r['body']['code']])) {
-      $this->proto->useCluster($this->conn->hello());
-      $this->conn= $this->proto->establish([$this->proto->nodes['primary']], 'writing');
-      goto retry;
-    }
+      // Retry "NotWritablePrimary" errors, replacing the connection
+      if ($this->retry && isset(Error::NOT_PRIMARY[$r['body']['code']])) {
+        $this->proto->useCluster($this->conn->hello());
+        $this->conn= $this->proto->establish([$this->proto->nodes['primary']], 'writing');
+        $this->retry= false;
+        goto retry;
+      }
 
-    throw Error::newInstance($r['body']);
+      throw Error::newInstance($r['body']);
+    } finally {
+      $this->retry= false;
+    }
   }
 }

--- a/src/main/php/com/mongodb/io/Commands.class.php
+++ b/src/main/php/com/mongodb/io/Commands.class.php
@@ -77,7 +77,7 @@ class Commands {
     }
 
     // Retry "NotWritablePrimary" errors, replacing the connection
-    if ($this->retry-- && isset(Protocol::NOT_PRIMARY[$r['body']['code']])) {
+    if ($this->retry-- && isset(Error::NOT_PRIMARY[$r['body']['code']])) {
       $this->proto->useCluster($this->conn->hello());
       $this->conn= $this->proto->establish([$this->proto->nodes['primary']], 'writing');
       goto retry;

--- a/src/main/php/com/mongodb/io/Connection.class.php
+++ b/src/main/php/com/mongodb/io/Connection.class.php
@@ -223,6 +223,7 @@ class Connection {
     $response= $this->read0($meta['messageLength'] - 16);
     $this->lastUsed= time();
 
+    // TODO: Use unpack(..., offset: X) instead of substr() when we drop PHP 7.0 support
     switch ($meta['opCode']) {
       case self::OP_MSG:
         $flags= unpack('V', substr($response, 0, 4))[1];

--- a/src/main/php/com/mongodb/io/Connection.class.php
+++ b/src/main/php/com/mongodb/io/Connection.class.php
@@ -124,7 +124,7 @@ class Connection {
       $auth ?? $auth= Authentication::negotiate($document['saslSupportedMechs'] ?? []);
       $conversation= $auth->conversation($user, $pass, $authSource);
       do {
-        $result= $this->message($conversation->current(), null);
+        $result= $this->send(self::OP_MSG, "\x00\x00\x00\x00\x00", $conversation->current());
         if (0 === (int)$result['body']['ok']) {
           throw Error::newInstance($result['body']);
         }
@@ -197,23 +197,6 @@ class Connection {
       $n-= strlen($chunk);
     } while ($n > 0);
     return $b;
-  }
-
-  /**
-   * Sends a message, raising errors for non-OK responses.
-   * 
-   * @param  [:var] $sections
-   * @param  ?string $readPreference
-   * @return var
-   * @throws com.mongodb.Error
-   */
-  public function message($sections, $readPreference) {
-
-    // flags(V)= 0, kind(c)= 0
-    $r= $this->send(self::OP_MSG, "\x00\x00\x00\x00\x00", $sections, $readPreference);
-    if (1 === (int)$r['body']['ok']) return $r;
-
-    throw Error::newInstance($r['body']);
   }
 
   /**

--- a/src/main/php/com/mongodb/io/Connection.class.php
+++ b/src/main/php/com/mongodb/io/Connection.class.php
@@ -77,7 +77,7 @@ class Connection {
    *
    * @param  [:var] $options
    * @param  ?com.mongodb.auth.Mechanism $auth
-   * @return void
+   * @return [:var]
    * @throws com.mongodb.AuthenticationFailed
    * @throws peer.ConnectException
    */
@@ -92,10 +92,7 @@ class Connection {
       }
     }
 
-    // Send hello package and determine connection kind
-    // https://www.mongodb.com/docs/manual/reference/command/hello/
-    $hello= [
-      'hello'    => 1,
+    $params= [
       'client'   => [
         'application' => ['name' => $options['params']['appName'] ?? $_SERVER['argv'][0] ?? 'php'],
         'driver'      => ['name' => 'XP MongoDB Connectivity', 'version' => '1.0.0'],
@@ -109,20 +106,53 @@ class Connection {
       $user= urldecode($options['user']);
       $pass= urldecode($options['pass']);
       $authSource= $options['params']['authSource'] ?? (isset($options['path']) ? ltrim($options['path'], '/') : 'admin');
-      $hello['saslSupportedMechs']= "{$authSource}.{$user}";
+      $params['saslSupportedMechs']= "{$authSource}.{$user}";
     } else {
       $authSource= null;
     }
 
     try {
-      $reply= $this->send(
-        self::OP_QUERY,
-        "\x00\x00\x00\x00admin.\$cmd\x00\x00\x00\x00\x00\x01\x00\x00\x00",
-        $hello
-      );
+      $this->server= $this->hello($params);
     } catch (ProtocolException $e) {
       throw new ConnectException('Server handshake failed @ '.$this->address(), $e);
     }
+
+    // Optionally, perform authentication
+    if (null === $authSource) return $this->server;
+
+    try {
+      $auth ?? $auth= Authentication::negotiate($document['saslSupportedMechs'] ?? []);
+      $conversation= $auth->conversation($user, $pass, $authSource);
+      do {
+        $result= $this->message($conversation->current(), null);
+        if (0 === (int)$result['body']['ok']) {
+          throw Error::newInstance($result['body']);
+        }
+
+        $conversation->send($result['body']);
+      } while ($conversation->valid());
+
+      return $this->server;
+    } catch (Throwable $t) {
+      throw new AuthenticationFailed($t->getMessage(), $options['user'], new Secret($options['pass']), $t);
+    }
+  }
+
+  /**
+   * Sends "hello" command and returns result to determine the state of the
+   * replica set members and to discover additional members of a replica set.
+   *
+   * @see    https://www.mongodb.com/docs/current/reference/command/hello/
+   * @param  [:var] $command
+   * @return [:var]
+   * @throws peer.ProtocolException
+   */
+  public function hello($command= []) {
+    $reply= $this->send(
+      self::OP_QUERY,
+      "\x00\x00\x00\x00admin.\$cmd\x00\x00\x00\x00\x00\x01\x00\x00\x00",
+      ['hello' => 1] + $command
+    );
 
     // See https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#type
     $document= &$reply['documents'][0];
@@ -144,25 +174,8 @@ class Connection {
     } else if ('isdbgrid' === ($document['msg'] ?? '')) {
       $kind= self::Mongos;
     }
-    $this->server= ['$kind' => $kind] + $document;
 
-    // Optionally, perform authentication
-    if (null === $authSource) return;
-
-    try {
-      $auth ?? $auth= Authentication::negotiate($document['saslSupportedMechs'] ?? []);
-      $conversation= $auth->conversation($user, $pass, $authSource);
-      do {
-        $result= $this->message($conversation->current(), null);
-        if (0 === (int)$result['body']['ok']) {
-          throw Error::newInstance($result['body']);
-        }
-
-        $conversation->send($result['body']);
-      } while ($conversation->valid());
-    } catch (Throwable $t) {
-      throw new AuthenticationFailed($t->getMessage(), $options['user'], new Secret($options['pass']), $t);
-    }
+    return ['$kind' => $kind] + $document;
   }
 
   /**
@@ -187,7 +200,7 @@ class Connection {
   }
 
   /**
-   * Sends a message
+   * Sends a message, raising errors for non-OK responses.
    * 
    * @param  [:var] $sections
    * @param  ?string $readPreference
@@ -195,12 +208,9 @@ class Connection {
    * @throws com.mongodb.Error
    */
   public function message($sections, $readPreference) {
-    if (null !== $readPreference && self::Standalone !== $this->server['$kind']) {
-      $sections+= ['$readPreference' => $readPreference];
-    }
 
     // flags(V)= 0, kind(c)= 0
-    $r= $this->send(self::OP_MSG, "\x00\x00\x00\x00\x00", $sections);
+    $r= $this->send(self::OP_MSG, "\x00\x00\x00\x00\x00", $sections, $readPreference);
     if (1 === (int)$r['body']['ok']) return $r;
 
     throw Error::newInstance($r['body']);
@@ -212,10 +222,15 @@ class Connection {
    * @param  int $operation One of the OP_* constants
    * @param  string $header
    * @param  [:var] $sections
+   * @param  ?string $readPreference
    * @return var
    * @throws peer.ProtocolException
    */
-  public function send($operation, $header, $sections) {
+  public function send($operation, $header, $sections, $readPreference= null) {
+    if (null !== $readPreference && self::Standalone !== $this->server['$kind']) {
+      $sections+= ['$readPreference' => $readPreference];
+    }
+
     $this->packet > 2147483647 ? $this->packet= 1 : $this->packet++;
     $body= $header.$this->bson->sections($sections);
     $payload= pack('VVVV', strlen($body) + 16, $this->packet, 0, $operation).$body;

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -270,9 +270,8 @@ class Protocol {
     // Check for "NotWritablePrimary" error, which indicates our view of the cluster
     // may be outdated, see https://github.com/xp-forge/mongodb/issues/43. Refresh
     // view using the "hello" command, then retry the command once.
-    if ($retry && isset($NOT_PRIMARY[$r['body']['code']])) {
+    if ($retry-- && isset($NOT_PRIMARY[$r['body']['code']])) {
       $this->useCluster($conn->hello());
-      $retry--;
       goto retry;
     }
 

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -178,7 +178,7 @@ class Protocol {
    * @return void
    */
   private function useCluster($server) {
-    $this->nodes= ['primary' => $server['primary'] ?? $candidate, 'secondary' => []];
+    $this->nodes= ['primary' => $server['primary'] ?? key($this->conn), 'secondary' => []];
     foreach ($server['hosts'] ?? [] as $host) {
       if ($server['primary'] !== $host) $this->nodes['secondary'][]= $host;
     }

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -238,9 +238,11 @@ class Protocol {
     }
 
     $rp= $sections['$readPreference'] ?? $this->readPreference;
-    return $this->establish($this->candidates($rp), 'reading with '.$rp['mode'])
-      ->message($sections, $rp)
-    ;
+    $conn= $this->establish($this->candidates($rp), 'reading with '.$rp['mode']);
+    $r= $conn->send(Connection::OP_MSG, "\x00\x00\x00\x00\x00", $sections, $rp);
+    if (1 === (int)$r['body']['ok']) return $r;
+
+    throw Error::newInstance($r['body']);
   }
 
   /**

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -268,7 +268,7 @@ class Protocol {
     if (1 === (int)$r['body']['ok']) return $r;
 
     // Check for "NotWritablePrimary" error, which indicates our view of the cluster
-    // may be outdated, see https://github.com/xp-forge/mongodb/issues/42. Refresh
+    // may be outdated, see https://github.com/xp-forge/mongodb/issues/43. Refresh
     // view using the "hello" command, then retry the command once.
     if ($retry && isset($NOT_PRIMARY[$r['body']['code']])) {
       $this->useCluster($conn->hello());

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -13,8 +13,6 @@ use util\Objects;
  * @test  com.mongodb.unittest.ReplicaSetTest
  */
 class Protocol {
-  const NOT_PRIMARY= [10107 => 1, 11602 => 1, 13435 => 1, 13436 => 1];
-
   private $options;
   protected $auth= null;
   protected $conn= [];
@@ -270,7 +268,7 @@ class Protocol {
     // Check for "NotWritablePrimary" error, which indicates our view of the cluster
     // may be outdated, see https://github.com/xp-forge/mongodb/issues/43. Refresh
     // view using the "hello" command, then retry the command once.
-    if ($retry-- && isset(self::NOT_PRIMARY[$r['body']['code']])) {
+    if ($retry-- && isset(Error::NOT_PRIMARY[$r['body']['code']])) {
       $this->useCluster($conn->hello());
       goto retry;
     }

--- a/src/test/php/com/mongodb/unittest/CollectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionTest.class.php
@@ -328,7 +328,7 @@ class CollectionTest {
     $fixture->update('6100', ['$inc' => ['qty' => 1]]);
   }
 
-  #[Test, Values('writes')]
+  #[Test, Values(from: 'writes')]
   public function not_writable_primary_retried($kind, $command) {
     $command($this->newFixture(
       $this->error(10107, 'NotWritablePrimary'),
@@ -337,7 +337,7 @@ class CollectionTest {
     ));
   }
 
-  #[Test, Expect(class: Error::class, message: 'Second occurrence'), Values('writes')]
+  #[Test, Expect(class: Error::class, message: 'Second occurrence'), Values(from: 'writes')]
   public function not_writable_primary_not_retried_more_than_once($kind, $command) {
     $command($this->newFixture(
       $this->error(10107, 'NotWritablePrimary', 'First occurrence'),

--- a/src/test/php/com/mongodb/unittest/CollectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionTest.class.php
@@ -314,13 +314,29 @@ class CollectionTest {
   }
 
   #[Test]
-  public function not_writable_primary_retried() {
+  public function not_writable_primary_retried_during_update() {
     $fixture= $this->newFixture(
       $this->error(10107, 'NotWritablePrimary'),
       $this->hello(self::$PRIMARY),
       $this->ok(['n' => 1, 'nModified' => 1])
     );
     $fixture->update('6100', ['$inc' => ['qty' => 1]]);
+  }
+
+  #[Test]
+  public function not_writable_primary_retried_during_run() {
+    $fixture= $this->newFixture(
+      $this->error(10107, 'NotWritablePrimary'),
+      $this->hello(self::$PRIMARY),
+      $this->ok(['n' => 1, 'nModified' => 1])
+    );
+
+    $fixture->run('findAndModify', [
+      'query'  => ['id' => '6100'],
+      'update' => ['$inc' => ['qty' => 1]],
+      'new'    => true,  // Return modified document
+      'upsert' => true,
+    ]);
   }
 
   #[Test, Expect(class: Error::class, message: 'Second occurrance')]

--- a/src/test/php/com/mongodb/unittest/CollectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionTest.class.php
@@ -312,4 +312,24 @@ class CollectionTest {
     $fixture= $this->newFixture($this->error(6100, 'TestingError', 'Test'));
     $fixture->update('6100', ['$inc' => ['qty' => 1]]);
   }
+
+  #[Test]
+  public function not_writable_primary_retried() {
+    $fixture= $this->newFixture(
+      $this->error(10107, 'NotWritablePrimary'),
+      $this->hello(self::$PRIMARY),
+      $this->ok(['n' => 1, 'nModified' => 1])
+    );
+    $fixture->update('6100', ['$inc' => ['qty' => 1]]);
+  }
+
+  #[Test, Expect(class: Error::class, message: 'Second occurrance')]
+  public function not_writable_primary_not_retried_more_than_once() {
+    $fixture= $this->newFixture(
+      $this->error(10107, 'NotWritablePrimary', 'First occurrance'),
+      $this->hello(self::$PRIMARY),
+      $this->error(10107, 'NotWritablePrimary', 'Second occurrance')
+    );
+    $fixture->update('6100', ['$inc' => ['qty' => 1]]);
+  }
 }

--- a/src/test/php/com/mongodb/unittest/TestingConnection.class.php
+++ b/src/test/php/com/mongodb/unittest/TestingConnection.class.php
@@ -26,10 +26,14 @@ class TestingConnection extends Connection {
    * @param  int $operation One of the OP_* constants
    * @param  string $header
    * @param  [:var] $sections
+   * @param  ?string $readPreference
    * @return var
    * @throws peer.ProtocolException
    */
-  public function send($operation, $header, $sections) {
+  public function send($operation, $header, $sections, $readPreference= null) {
+    if (null !== $readPreference && self::Standalone !== $this->server['$kind']) {
+      $sections+= ['$readPreference' => $readPreference];
+    }
     $this->sent[]= $sections;
 
     $reply= $this->replies ? array_shift($this->replies) : null;


### PR DESCRIPTION
The clientside cluster view may become outdated, causing us to erroneously write to non-primary nodes. This is how this can occur (see https://github.com/xp-forge/mongodb/issues/42#issuecomment-1712795735):

| Event                   | Client view                     | Server side situation           |
| ----------------------- | ------------------------------- | ------------------------------- |
| Client: Before          | (n/a)                           | {Primary: A, Secondary: [B, C]} |
| Client: Connect         | {Primary: A, Secondary: [B, C]} | {Primary: A, Secondary: [B, C]} |
| Remote: Primary change  | {Primary: A, Secondary: [B, C]} | {Primary: B, Secondary: [A, C]} |
| Client: Write           | {Primary: A, Secondary: [B, C]} | {Primary: B, Secondary: [A, C]} |

The client has an inconsistent view of the server side situation and uses node `A` for writing which it believes to be the primary, while in reality it's changed its role to a secondary.

If we encounter an error indicating this condition, we now refresh the cluster view, then retry the write once.

