### PR TITLE
Add equals() methods for wrapper classes

### DIFF
--- a/src/main/php/com/mongodb/Code.class.php
+++ b/src/main/php/com/mongodb/Code.class.php
@@ -35,4 +35,14 @@ class Code implements Value {
   public function compareTo($value) {
     return $value instanceof self ? $this->source <=> $value->source : 1;
   }
+
+  /**
+   * Test for equality
+   *
+   * @param  var $value
+   * @return bool
+   */
+  public function equals($value) {
+    return $value instanceof self ? 0 === ($this->source <=> $value->source) : false;
+  }
 }

--- a/src/main/php/com/mongodb/Collection.class.php
+++ b/src/main/php/com/mongodb/Collection.class.php
@@ -119,6 +119,27 @@ class Collection implements Value {
   }
 
   /**
+   * Modifies document using `findAndModify`
+   *
+   * @param  string|com.mongodb.ObjectId|[:var] $query
+   * @param  [:var]|com.mongodb.Document $arg Update operator expressions or document
+   * @param  bool $upsert
+   * @param  com.mongodb.Options... $options
+   * @return com.mongodb.result.Modification
+   * @throws com.mongodb.Error
+   */
+  public function modify($query, $update, $upsert= true, Options... $options) {
+    $result= $this->proto->write($options, [
+      'findAndModify' => $this->name,
+      'query'         => is_array($query) ? $query : ['_id' => $query],
+      'update'        => $update,
+      'upsert'        => $upsert,
+      'new'           => true,  // Return modified document
+    ]);
+    return new Modification($result['body']);
+  }
+
+  /**
    * Delete documents
    *
    * @param  string|com.mongodb.ObjectId|[:var] $query

--- a/src/main/php/com/mongodb/Decimal128.class.php
+++ b/src/main/php/com/mongodb/Decimal128.class.php
@@ -137,4 +137,14 @@ class Decimal128 implements Value {
   public function compareTo($value) {
     return $value instanceof self ? $this->__toString() <=> $value->__toString() : 1;
   }
+
+  /**
+   * Test for equality
+   *
+   * @param  var $value
+   * @return bool
+   */
+  public function equals($value) {
+    return $value instanceof self ? 0 === ($this->__toString() <=> $value->__toString()) : false;
+  }
 }

--- a/src/main/php/com/mongodb/Int64.class.php
+++ b/src/main/php/com/mongodb/Int64.class.php
@@ -32,4 +32,14 @@ class Int64 implements Value {
   public function compareTo($value) {
     return $value instanceof self ? $this->number <=> $value->number : 1;
   }
+
+  /**
+   * Test for equality
+   *
+   * @param  var $value
+   * @return bool
+   */
+  public function equals($value) {
+    return $value instanceof self ? 0 === ($this->number <=> $value->number) : false;
+  }
 }

--- a/src/main/php/com/mongodb/ObjectId.class.php
+++ b/src/main/php/com/mongodb/ObjectId.class.php
@@ -67,4 +67,14 @@ class ObjectId implements Value {
   public function compareTo($value) {
     return $value instanceof self ? $this->string <=> $value->string : 1;
   }
+
+  /**
+   * Test for equality
+   *
+   * @param  var $value
+   * @return bool
+   */
+  public function equals($value) {
+    return $value instanceof self ? 0 === ($this->string <=> $value->string) : false;
+  }
 }

--- a/src/test/php/com/mongodb/unittest/CodeTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CodeTest.class.php
@@ -41,4 +41,10 @@ class CodeTest {
     Assert::equals(0, (new Code(self::SOURCE))->compareTo(new Code(self::SOURCE)));
     Assert::equals(1, (new Code(self::SOURCE))->compareTo(new Code('')));
   }
+
+  #[Test]
+  public function equals() {
+    Assert::true((new Code(self::SOURCE))->equals(new Code(self::SOURCE)));
+    Assert::false((new Code(self::SOURCE))->equals(new Code('')));
+  }
 }

--- a/src/test/php/com/mongodb/unittest/Decimal128Test.class.php
+++ b/src/test/php/com/mongodb/unittest/Decimal128Test.class.php
@@ -56,4 +56,12 @@ class Decimal128Test {
     Assert::equals(new Decimal128($n), $fixture);
     Assert::notEquals(new Decimal128(6100), $fixture);
   }
+
+  #[Test, Values(from: 'numbers')]
+  public function equals($n) {
+    $fixture= new Decimal128($n);
+
+    Assert::true((new Decimal128($n))->equals($fixture));
+    Assert::false((new Decimal128(6100))->equals($fixture));
+  }
 }

--- a/src/test/php/com/mongodb/unittest/Int64Test.class.php
+++ b/src/test/php/com/mongodb/unittest/Int64Test.class.php
@@ -46,4 +46,12 @@ class Int64Test {
     Assert::equals(new Int64($n), $fixture);
     Assert::notEquals(new Int64(6100), $fixture);
   }
+
+  #[Test, Values(from: 'numbers')]
+  public function equals($n) {
+    $fixture= new Int64($n);
+
+    Assert::true((new Int64($n))->equals($fixture));
+    Assert::false((new Int64(6100))->equals($fixture));
+  }
 }

--- a/src/test/php/com/mongodb/unittest/ObjectIdTest.class.php
+++ b/src/test/php/com/mongodb/unittest/ObjectIdTest.class.php
@@ -38,6 +38,12 @@ class ObjectIdTest {
   }
 
   #[Test]
+  public function equals() {
+    Assert::true((new ObjectId(self::ID))->equals(new ObjectId(self::ID)));
+    Assert::false((new ObjectId(self::ID))->equals(new ObjectId('4f1dda9973edf2501751884b')));
+  }
+
+  #[Test]
   public function create() {
     Assert::matches('/^[0-9a-f]{24}$/', ObjectId::create());
   }


### PR DESCRIPTION
## Example

The following code becomes clearer:

```diff
  $user= ...
  foreach ($comments as $comment) {
-   if (0 === $comment['user']['id']->compareTo($user->id()) {
+   if ($comment['user']['id']->equals($user->id()) { 
      // Comment was made by user
    }
  }
```

## Wrapper classes

These classes now have an `equals()` method alongside `compareTo()`:

* [x] ObjectId
* [x] Int64
* [x] Decimal128
* [x] Code 

The `MinKey`, `MaxKey` and `Timestamp` classes do not have this method.
