### PR TITLE
Implement Collection `modify()` and `remove()`  via findAndModify

### DIFF
--- a/src/main/php/com/mongodb/Collection.class.php
+++ b/src/main/php/com/mongodb/Collection.class.php
@@ -119,21 +119,21 @@ class Collection implements Value {
   }
 
   /**
-   * Modifies collection with given statements and returns a `Modification`
-   * instance with the modified document.
+   * Modifies collection and returns a `Modification` instance with the modified
+   * document.
    *
    * @param  string|com.mongodb.ObjectId|[:var] $query
-   * @param  [:var] $statements Update operator expressions
+   * @param  [:var]|com.mongodb.Document $arg Update operator expressions or document
    * @param  bool $upsert
    * @param  com.mongodb.Options... $options
    * @return com.mongodb.result.Modification
    * @throws com.mongodb.Error
    */
-  public function modify($query, $statements, $upsert= false, Options... $options): Modification {
+  public function modify($query, $arg, $upsert= false, Options... $options): Modification {
     $result= $this->proto->write($options, [
       'findAndModify' => $this->name,
       'query'         => is_array($query) ? $query : ['_id' => $query],
-      'update'        => $statements,
+      'update'        => $arg,
       'new'           => true,
       'upsert'        => $upsert,
       '$db'           => $this->database,

--- a/src/main/php/com/mongodb/Collection.class.php
+++ b/src/main/php/com/mongodb/Collection.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb;
 
 use com\mongodb\io\{Commands, Protocol};
-use com\mongodb\result\{Insert, Update, Delete, Cursor, Run, ChangeStream};
+use com\mongodb\result\{Insert, Update, Delete, Modification, Cursor, Run, ChangeStream};
 use lang\Value;
 use util\Objects;
 
@@ -97,7 +97,7 @@ class Collection implements Value {
   }
 
   /**
-   * Updates collection with given modifications.
+   * Updates collection with given statements.
    *
    * @param  string|com.mongodb.ObjectId|[:var] $query
    * @param  [:var] $statements Update operator expressions
@@ -116,6 +116,29 @@ class Collection implements Value {
       '$db'       => $this->database,
     ]);
     return new Update($result['body']);
+  }
+
+  /**
+   * Modifies collection with given statements and returns a `Modification`
+   * instance with the modified document.
+   *
+   * @param  string|com.mongodb.ObjectId|[:var] $query
+   * @param  [:var] $statements Update operator expressions
+   * @param  bool $upsert
+   * @param  com.mongodb.Options... $options
+   * @return com.mongodb.result.Modification
+   * @throws com.mongodb.Error
+   */
+  public function modify($query, $statements, $upsert= false, Options... $options): Modification {
+    $result= $this->proto->write($options, [
+      'findAndModify' => $this->name,
+      'query'         => is_array($query) ? $query : ['_id' => $query],
+      'update'        => $statements,
+      'new'           => true,
+      'upsert'        => $upsert,
+      '$db'           => $this->database,
+    ]);
+    return new Modification($result['body']);
   }
 
   /**

--- a/src/main/php/com/mongodb/Collection.class.php
+++ b/src/main/php/com/mongodb/Collection.class.php
@@ -163,6 +163,27 @@ class Collection implements Value {
   }
 
   /**
+   * Modifies collection and returns a `Modification` instance with the removed
+   * document.
+   *
+   * @param  string|com.mongodb.ObjectId|[:var] $query
+   * @param  [:var]|com.mongodb.Document $arg Update operator expressions or document
+   * @param  bool $upsert
+   * @param  com.mongodb.Options... $options
+   * @return com.mongodb.result.Modification
+   * @throws com.mongodb.Error
+   */
+  public function remove($query, Options... $options): Modification {
+    $result= $this->proto->write($options, [
+      'findAndModify' => $this->name,
+      'query'         => is_array($query) ? $query : ['_id' => $query],
+      'remove'        => true,
+      '$db'           => $this->database,
+    ]);
+    return new Modification($result['body']);
+  }
+
+  /**
    * Find documents in this collection
    *
    * @param  string|com.mongodb.ObjectId|[:var] $query

--- a/src/main/php/com/mongodb/result/Modification.class.php
+++ b/src/main/php/com/mongodb/result/Modification.class.php
@@ -2,7 +2,14 @@
 
 use com\mongodb\Document;
 
-/** @test com.mongodb.unittest.result.ModificationTest */
+/**
+ * The result of a `findAndModify` operation
+ *
+ * @see  com.mongodb.Collection::modify
+ * @see  com.mongodb.Collection::remove
+ * @see  https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+ * @test com.mongodb.unittest.result.ModificationTest
+ */
 class Modification extends Result {
   const REMOVED= 'removed';
   const CREATED= 'created';

--- a/src/main/php/com/mongodb/result/Modification.class.php
+++ b/src/main/php/com/mongodb/result/Modification.class.php
@@ -32,7 +32,7 @@ class Modification extends Result {
   /**
    * Returns the upserted ID, if any
    *
-   * @return ?com.mongodb.ObjectId
+   * @return ?(string|com.mongodb.ObjectId)
    */
   public function upserted() {
     return $this->result['lastErrorObject']['upserted'] ?? null;

--- a/src/main/php/com/mongodb/result/Modification.class.php
+++ b/src/main/php/com/mongodb/result/Modification.class.php
@@ -4,13 +4,22 @@ use com\mongodb\Document;
 
 /** @test com.mongodb.unittest.result.ModificationTest */
 class Modification extends Result {
+  const REMOVED= 'removed';
+  const CREATED= 'created';
+  const UPDATED= 'updated';
 
   /** Returns number of modified documents */
   public function modified(): int { return $this->result['lastErrorObject']['n']; }
 
-  /** Returns whether an existing document was updated */
-  public function updatedExisting(): bool {
-    return $this->result['lastErrorObject']['updatedExisting'];
+  /** Returns kind of modification: created, updated or removed. */
+  public function kind(): string {
+    if (isset($this->result['lastErrorObject']['upserted'])) {
+      return self::CREATED;
+    } else if (isset($this->result['lastErrorObject']['updatedExisting'])) {
+      return self::UPDATED;
+    } else {
+      return self::REMOVED;
+    }
   }
 
   /**

--- a/src/main/php/com/mongodb/result/Modification.class.php
+++ b/src/main/php/com/mongodb/result/Modification.class.php
@@ -1,0 +1,33 @@
+<?php namespace com\mongodb\result;
+
+use com\mongodb\Document;
+
+/** @test com.mongodb.unittest.result.ModificationTest */
+class Modification extends Result {
+
+  /** Returns number of modified documents */
+  public function modified(): int { return $this->result['lastErrorObject']['n']; }
+
+  /** Returns whether an existing document was updated */
+  public function updatedExisting(): bool {
+    return $this->result['lastErrorObject']['updatedExisting'];
+  }
+
+  /**
+   * Returns the upserted ID, if any
+   *
+   * @return ?com.mongodb.ObjectId
+   */
+  public function upserted() {
+    return $this->result['lastErrorObject']['upserted'] ?? null;
+  }
+
+  /**
+   * Returns the document
+   *
+   * @return ?com.mongodb.Document
+   */
+  public function document() {
+    return isset($this->result['value']) ? new Document($this->result['value']) : null;
+  }
+}

--- a/src/main/php/com/mongodb/result/Update.class.php
+++ b/src/main/php/com/mongodb/result/Update.class.php
@@ -12,7 +12,7 @@ class Update extends Result {
   /**
    * Returns IDs from an upsert, or an empty array if no upsers were performed.
    *
-   * @return (string|com.mongodb.ObjectId)[]
+   * @return com.mongodb.ObjectId[]
    */
   public function upserted(): array {
     $r= [];

--- a/src/main/php/com/mongodb/result/Update.class.php
+++ b/src/main/php/com/mongodb/result/Update.class.php
@@ -12,7 +12,7 @@ class Update extends Result {
   /**
    * Returns IDs from an upsert, or an empty array if no upsers were performed.
    *
-   * @return com.mongodb.ObjectId[]
+   * @return (string|com.mongodb.ObjectId)[]
    */
   public function upserted(): array {
     $r= [];

--- a/src/test/php/com/mongodb/unittest/CollectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionTest.class.php
@@ -140,6 +140,47 @@ class CollectionTest {
   }
 
   #[Test]
+  public function modify_none() {
+    $body= $this->ok([
+      'lastErrorObject' => ['n' => 0, 'updatedExisting' => false],
+      'value'           => null,
+    ]);
+    $result= $this->newFixture($body)->modify(ObjectId::create(), ['$set' => ['test' => true]]);
+
+    Assert::equals([false, 0], [$result->updatedExisting(), $result->modified()]);
+    Assert::null($result->upserted());
+    Assert::null($result->document());
+  }
+
+  #[Test]
+  public function modify_existing() {
+    $doc= new Document(['_id' => ObjectId::create(), 'test' => true]);
+    $body= $this->ok([
+      'lastErrorObject' => ['n' => 1, 'updatedExisting' => true],
+      'value'           => $doc->properties(),
+    ]);
+    $result= $this->newFixture($body)->modify($doc->id(), ['$set' => ['test' => true]]);
+
+    Assert::equals([true, 1], [$result->updatedExisting(), $result->modified()]);
+    Assert::null($result->upserted());
+    Assert::equals($doc, $result->document());
+  }
+
+  #[Test]
+  public function create_new() {
+    $doc= new Document(['_id' => ObjectId::create(), 'test' => true]);
+    $body= $this->ok([
+      'lastErrorObject' => ['n' => 1, 'updatedExisting' => false, 'upserted' => $doc->id()],
+      'value'           => $doc->properties(),
+    ]);
+    $result= $this->newFixture($body)->modify($doc->id(), ['$set' => ['test' => true]]);
+
+    Assert::equals([false, 1], [$result->updatedExisting(), $result->modified()]);
+    Assert::equals($doc->id(), $result->upserted());
+    Assert::equals($doc, $result->document());
+  }
+
+  #[Test]
   public function delete_one() {
     $result= $this->newFixture($this->ok(['n' => 1]))->delete('6100');
 

--- a/src/test/php/com/mongodb/unittest/result/ModificationTest.class.php
+++ b/src/test/php/com/mongodb/unittest/result/ModificationTest.class.php
@@ -7,8 +7,8 @@ use test\{Assert, Before, Test};
 class ModificationTest {
   private $objectId;
 
-  /** Creates a result */
-  private function result(Document $document= null, $created= false) {
+  /** Creates a result from an update operation */
+  private function update(Document $document= null, $created= false) {
     if (null === $document) {
       $lastErrorObject= ['n' => 0, 'updatedExisting' => false];
       $value= null;
@@ -22,6 +22,18 @@ class ModificationTest {
     return ['lastErrorObject' => $lastErrorObject, 'value' => $value, 'ok' => 1];
   }
 
+  /** Creates a result from a remove operation */
+  private function remove(Document $document= null) {
+    if (null === $document) {
+      $lastErrorObject= ['n' => 0];
+      $value= null;
+    } else {
+      $lastErrorObject= ['n' => 1];
+      $value= $document->properties();
+    }
+    return ['lastErrorObject' => $lastErrorObject, 'value' => $value, 'ok' => 1];
+  }
+
   #[Before]
   public function objectId() {
     $this->objectId= ObjectId::create();
@@ -29,52 +41,68 @@ class ModificationTest {
 
   #[Test]
   public function can_create() {
-    new Modification($this->result());
+    new Modification($this->update());
   }
 
   #[Test]
   public function none_modified() {
-    Assert::equals(0, (new Modification($this->result()))->modified());
+    Assert::equals(0, (new Modification($this->update()))->modified());
   }
 
   #[Test]
   public function modified() {
     $doc= new Document(['test' => true]);
-    Assert::equals(1, (new Modification($this->result($doc)))->modified());
+    Assert::equals(1, (new Modification($this->update($doc)))->modified());
   }
 
   #[Test]
   public function updated_existing() {
     $doc= new Document(['_id' => $this->objectId, 'test' => true]);
-    Assert::true((new Modification($this->result($doc)))->updatedExisting());
+    Assert::equals(Modification::UPDATED, ((new Modification($this->update($doc)))->kind()));
   }
 
   #[Test]
   public function created_new() {
     $doc= new Document(['_id' => $this->objectId, 'test' => true]);
-    Assert::false((new Modification($this->result($doc, true)))->updatedExisting());
+    Assert::equals(Modification::CREATED, (new Modification($this->update($doc, true)))->kind());
   }
 
   #[Test]
   public function not_upserted() {
     $doc= new Document(['_id' => $this->objectId, 'test' => true]);
-    Assert::null((new Modification($this->result($doc)))->upserted());
+    Assert::null((new Modification($this->update($doc)))->upserted());
   }
 
   #[Test]
   public function upserted_id() {
     $doc= new Document(['_id' => $this->objectId, 'test' => true]);
-    Assert::equals($this->objectId, (new Modification($this->result($doc, true)))->upserted());
+    Assert::equals($this->objectId, (new Modification($this->update($doc, true)))->upserted());
   }
 
   #[Test]
   public function document() {
     $doc= new Document(['_id' => $this->objectId, 'test' => true]);
-    Assert::equals($doc, (new Modification($this->result($doc)))->document());
+    Assert::equals($doc, (new Modification($this->update($doc)))->document());
   }
 
   #[Test]
   public function no_document() {
-    Assert::null((new Modification($this->result()))->document());
+    Assert::null((new Modification($this->update()))->document());
+  }
+
+  #[Test]
+  public function removed() {
+    $doc= new Document(['_id' => $this->objectId, 'test' => true]);
+    Assert::equals($doc, (new Modification($this->remove($doc)))->document());
+  }
+
+  #[Test]
+  public function not_removed() {
+    Assert::null((new Modification($this->remove()))->document());
+  }
+
+  #[Test]
+  public function removal_kind() {
+    Assert::equals(Modification::REMOVED, (new Modification($this->remove()))->kind());
   }
 }

--- a/src/test/php/com/mongodb/unittest/result/ModificationTest.class.php
+++ b/src/test/php/com/mongodb/unittest/result/ModificationTest.class.php
@@ -1,0 +1,80 @@
+<?php namespace com\mongodb\unittest\result;
+
+use com\mongodb\result\Modification;
+use com\mongodb\{Document, ObjectId};
+use test\{Assert, Before, Test};
+
+class ModificationTest {
+  private $objectId;
+
+  /** Creates a result */
+  private function result(Document $document= null, $created= false) {
+    if (null === $document) {
+      $lastErrorObject= ['n' => 0, 'updatedExisting' => false];
+      $value= null;
+    } else if ($created) {
+      $lastErrorObject= ['n' => 1, 'updatedExisting' => false, 'upserted' => $document->id()];
+      $value= $document->properties();
+    } else {
+      $lastErrorObject= ['n' => 1, 'updatedExisting' => true];
+      $value= $document->properties();
+    }
+    return ['lastErrorObject' => $lastErrorObject, 'value' => $value, 'ok' => 1];
+  }
+
+  #[Before]
+  public function objectId() {
+    $this->objectId= ObjectId::create();
+  }
+
+  #[Test]
+  public function can_create() {
+    new Modification($this->result());
+  }
+
+  #[Test]
+  public function none_modified() {
+    Assert::equals(0, (new Modification($this->result()))->modified());
+  }
+
+  #[Test]
+  public function modified() {
+    $doc= new Document(['test' => true]);
+    Assert::equals(1, (new Modification($this->result($doc)))->modified());
+  }
+
+  #[Test]
+  public function updated_existing() {
+    $doc= new Document(['_id' => $this->objectId, 'test' => true]);
+    Assert::true((new Modification($this->result($doc)))->updatedExisting());
+  }
+
+  #[Test]
+  public function created_new() {
+    $doc= new Document(['_id' => $this->objectId, 'test' => true]);
+    Assert::false((new Modification($this->result($doc, true)))->updatedExisting());
+  }
+
+  #[Test]
+  public function not_upserted() {
+    $doc= new Document(['_id' => $this->objectId, 'test' => true]);
+    Assert::null((new Modification($this->result($doc)))->upserted());
+  }
+
+  #[Test]
+  public function upserted_id() {
+    $doc= new Document(['_id' => $this->objectId, 'test' => true]);
+    Assert::equals($this->objectId, (new Modification($this->result($doc, true)))->upserted());
+  }
+
+  #[Test]
+  public function document() {
+    $doc= new Document(['_id' => $this->objectId, 'test' => true]);
+    Assert::equals($doc, (new Modification($this->result($doc)))->document());
+  }
+
+  #[Test]
+  public function no_document() {
+    Assert::null((new Modification($this->result()))->document());
+  }
+}


### PR DESCRIPTION
This pull requests adds new methods to the *Collection* class:

* `modify()` - much like *upsert*, with the difference that it also returns the modified document.
* `remove()` - same as *delete* but returns the document as it existed before deletion

These methods are slower by nature because of the document being part of the response payload. If you're not interested in the modified / deleted documents, simply use *upsert* and *delete*.

## Example

The following code becomes more concise:

```diff
  $statements= ['$set' => ['slug' => $slug, ...$entity]];
- $arguments= [
-   'query'  => ['slug' => $slug],
-   'update' => $statements,
-   'new'    => true,  // Return modified document
-   'upsert' => true,
- ];
- $value= $this->entries->run('findAndModify', $arguments)->value()['value'];
- $doc= $value ? new Document($value) : null; 
+ $doc= $this->entries->modify(['slug' => $slug], $statements, upsert: true)->document();
```

## See also

* https://www.mongodb.com/docs/manual/reference/command/findAndModify/
* https://stackoverflow.com/questions/10778493/whats-the-difference-between-findandmodify-and-update-in-mongodb