### PR TITLE
Defer connecting the MongoDB cluster until actual I/O is performed

### DIFF
--- a/src/main/php/com/mongodb/MongoConnection.class.php
+++ b/src/main/php/com/mongodb/MongoConnection.class.php
@@ -59,8 +59,6 @@ class MongoConnection implements Value {
    * @throws com.mongodb.Error
    */
   public function run($name, array $arguments= [], $semantics= 'write', Options... $options) {
-    $this->proto->connect();
-
     $commands= Commands::using($this->proto, $semantics);
     return new Run(
       $commands,
@@ -76,7 +74,6 @@ class MongoConnection implements Value {
    * @return com.mongodb.Session
    */
   public function session($uuid= null) {
-    $this->proto->connect();
 
     // From the spec: "Drivers SHOULD generate session IDs locally if possible
     // instead of running the startSession command, since running the command
@@ -85,19 +82,18 @@ class MongoConnection implements Value {
   }
 
   /**
-   * Selects a given database, connecting if necessary
+   * Selects a given database.
    *
    * @param  string $name The database name
    * @return com.mongodb.Database
    * @throws com.mongodb.Error
    */
   public function database(string $name): Database {
-    $this->proto->connect();
     return new Database($this->proto, $name);
   }
 
   /**
-   * Selects a given collection in a given database, connecting if necessary
+   * Selects a given collection in a given database.
    *
    * @param  string... $args A string "database.collection" or two arguments
    * @return com.mongodb.Collection
@@ -107,7 +103,6 @@ class MongoConnection implements Value {
   public function collection(... $args): Collection {
     $namespace= implode('.', $args);
     if (2 === sscanf($namespace, "%[^.].%[^\r]", $database, $collection)) {
-      $this->proto->connect();
       return new Collection($this->proto, $database, $collection);
     }
 
@@ -124,8 +119,6 @@ class MongoConnection implements Value {
    * @throws com.mongodb.Error
    */
   public function databases($filter= null, Options... $options) {
-    $this->proto->connect();
-
     $request= ['listDatabases' => 1, '$db' => 'admin'];
     if (null === $filter) {
       // NOOP
@@ -155,8 +148,6 @@ class MongoConnection implements Value {
    * @throws com.mongodb.Error
    */
   public function watch(array $pipeline= [], array $params= [], Options... $options): ChangeStream {
-    $this->proto->connect();
-
     array_unshift($pipeline, ['$changeStream' => ['allChangesForCluster' => true] + $params]);
 
     $commands= Commands::reading($this->proto);

--- a/src/main/php/com/mongodb/io/Commands.class.php
+++ b/src/main/php/com/mongodb/io/Commands.class.php
@@ -29,6 +29,7 @@ class Commands {
 
   /** Creates an instance for reading */
   public static function reading(Protocol $proto): self {
+    $proto->nodes || $proto->connect();
     return new self($proto, $proto->establish(
       $proto->candidates($proto->readPreference),
       'reading with '.$proto->readPreference['mode']
@@ -37,6 +38,7 @@ class Commands {
 
   /** Creates an instance for writing */
   public static function writing(Protocol $proto): self {
+    $proto->nodes || $proto->connect();
     return new self($proto, $proto->establish(
       [$proto->nodes['primary']],
       'writing'

--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -237,6 +237,7 @@ class Protocol {
    * @throws com.mongodb.Error
    */
   public function read(array $options, $sections) {
+    $this->nodes || $this->connect();
     foreach ($options as $option) {
       $sections+= $option->send($this);
     }
@@ -259,6 +260,7 @@ class Protocol {
    * @see    https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.yml
    */
   public function write(array $options, $sections) {
+    $this->nodes || $this->connect();
     foreach ($options as $option) {
       $sections+= $option->send($this);
     }

--- a/src/test/php/com/mongodb/unittest/MongoConnectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/MongoConnectionTest.class.php
@@ -84,30 +84,30 @@ class MongoConnectionTest {
   }
 
   #[Test]
-  public function connects_when_selecting_database() {
+  public function selecting_database() {
     $protocol= $this->protocol([$this->hello(self::$PRIMARY)]);
     $database= (new MongoConnection($protocol))->database('test');
 
     Assert::instance(Database::class, $database);
-    Assert::true($protocol->connections()[self::$PRIMARY]->connected());
+    Assert::false($protocol->connections()[self::$PRIMARY]->connected());
   }
 
   #[Test]
-  public function connects_when_selecting_collection_via_namespace() {
+  public function selecting_collection_via_namespace() {
     $protocol= $this->protocol([$this->hello(self::$PRIMARY)]);
     $collection= (new MongoConnection($protocol))->collection('test.products');
 
     Assert::instance(Collection::class, $collection);
-    Assert::true($protocol->connections()[self::$PRIMARY]->connected());
+    Assert::false($protocol->connections()[self::$PRIMARY]->connected());
   }
 
   #[Test]
-  public function connects_when_selecting_collection_via_args() {
+  public function selecting_collection_via_args() {
     $protocol= $this->protocol([$this->hello(self::$PRIMARY)]);
     $collection= (new MongoConnection($protocol))->collection('test', 'products');
 
     Assert::instance(Collection::class, $collection);
-    Assert::true($protocol->connections()[self::$PRIMARY]->connected());
+    Assert::false($protocol->connections()[self::$PRIMARY]->connected());
   }
 
   #[Test, Expect(IllegalArgumentException::class)]
@@ -116,12 +116,12 @@ class MongoConnectionTest {
   }
 
   #[Test]
-  public function connects_when_creating_session() {
+  public function creating_session() {
     $protocol= $this->protocol([$this->hello(self::$PRIMARY)]);
     $session= (new MongoConnection($protocol))->session();
 
     Assert::instance(Session::class, $session);
-    Assert::true($protocol->connections()[self::$PRIMARY]->connected());
+    Assert::false($protocol->connections()[self::$PRIMARY]->connected());
   }
 
   #[Test, Values([[null, []], ['test', ['filter' => ['name' => 'test']]], [['name' => 'test'], ['filter' => ['name' => 'test']]]])]


### PR DESCRIPTION
Implements the "lazy by default" option suggested in #50. This makes this library consistent with https://github.com/xp-framework/rdbms