### PR TITLE
Percent-decode credentials in connection strings

### DIFF
--- a/src/main/php/com/mongodb/io/Protocol.class.php
+++ b/src/main/php/com/mongodb/io/Protocol.class.php
@@ -43,8 +43,8 @@ class Protocol {
       $this->options= ['scheme' => 'mongodb', 'nodes' => substr($nodes, 1)] + $options;
     } else if (preg_match('/([^:]+):\/\/(([^:]+):([^@]+)@)?([^\/?]+)(\/[^?]*)?(\?(.+))?/', $arg, $m)) {
       $this->options= ['scheme' => $m[1], 'nodes' => $m[5]] + $options + ['params' => []];
-      '' === $m[3] || $this->options['user']= $m[3];
-      '' === $m[4] || $this->options['pass']= $m[4];
+      '' === $m[3] || $this->options['user']= urldecode($m[3]);
+      '' === $m[4] || $this->options['pass']= urldecode($m[4]);
       '' === ($m[6] ?? '') || $this->options['path']= $m[6];
 
       // Handle MongoDB Seed Lists

--- a/src/test/php/com/mongodb/unittest/ProtocolTest.class.php
+++ b/src/test/php/com/mongodb/unittest/ProtocolTest.class.php
@@ -27,6 +27,16 @@ class ProtocolTest {
     );
   }
 
+  #[Test]
+  public function urlencoded_user() {
+    Assert::equals('u:test', (new Protocol('mongodb://u%3atest:pass@localhost'))->options()['user']);
+  }
+
+  #[Test]
+  public function urlencoded_pass() {
+    Assert::equals('p:test', (new Protocol('mongodb://user:p%3atest@localhost'))->options()['pass']);
+  }
+
   #[Test, Values(['mongodb://localhost', 'mongodb://localhost?tls=true', 'mongodb://u:p@localhost', 'mongodb://one.local,two.local:27018,[::1]:27019'])]
   public function dsn_via_connection_string($uri) {
     Assert::equals($uri, (new Protocol($uri))->dsn(true));


### PR DESCRIPTION
> If the username or password includes the following characters, those characters must be converted using percent encoding:
> 
> `$ : / ? # [ ] @`

See https://www.mongodb.com/docs/manual/reference/connection-string/ and https://stackoverflow.com/questions/61824417/failedtoparse-password-must-be-url-encoded-for-mongodb