### PR TITLE
Raise exceptions when write errors occur during updates

### DIFF
--- a/src/main/php/com/mongodb/Collection.class.php
+++ b/src/main/php/com/mongodb/Collection.class.php
@@ -93,6 +93,8 @@ class Collection implements Value {
       ]],
       '$db'       => $this->database,
     ]);
+    if (isset($result['body']['writeErrors'])) throw new WriteErrors($result['body']);
+
     return new Update($result['body']);
   }
 
@@ -115,6 +117,8 @@ class Collection implements Value {
       'ordered'   => true,
       '$db'       => $this->database,
     ]);
+    if (isset($result['body']['writeErrors'])) throw new WriteErrors($result['body']);
+
     return new Update($result['body']);
   }
 

--- a/src/main/php/com/mongodb/Collection.class.php
+++ b/src/main/php/com/mongodb/Collection.class.php
@@ -8,7 +8,7 @@ use util\Objects;
 /**
  * A collection inside a database.
  *
- * @test  xp://com.mongodb.unittest.CollectionTest
+ * @test  com.mongodb.unittest.CollectionTest
  */
 class Collection implements Value {
   private $proto, $database, $name;

--- a/src/main/php/com/mongodb/WriteErrors.class.php
+++ b/src/main/php/com/mongodb/WriteErrors.class.php
@@ -1,0 +1,17 @@
+<?php namespace com\mongodb;
+
+use util\Objects;
+
+/** @see https://www.mongodb.com/docs/manual/reference/command/update/#mongodb-data-update.writeErrors */
+class WriteErrors extends Error {
+  public $result;
+
+  /** Creates a new instance of this error */
+  public function __construct($result) {
+    parent::__construct(112, 'WriteConflict', 'Write error(s) occurred: '.Objects::stringOf($result['writeErrors']));
+    $this->result= $result;
+  }
+
+  /** @return [:var][] */
+  public function list() { return $this->result['writeErrors']; }
+}


### PR DESCRIPTION
This pull request changes *update()* and *upsert()* to raise exceptions when write errors occur during the following:

```php
use com\mongodb\MongoConnection;

$c= new MongoConnection($dsn);
$c->collection('test.entries')->upsert(['test' => true], [
  '$inc' => ['version' => 1],
  '$setOnInsert' => ['version' => 1],
]);
```

This yields the following in the result:

```
writeErrors => [[
  index => 0
  code => 40
  errmsg => "Updating the path 'version' would create a conflict at 'version'"
]]
```

👉 The methods now throw a `com.mongodb.WriteErrors` exception which extends the `com.mongodb.Error` class.

## Accessing the errors

```php
use com\mongodb\{MongoConnection, WriteErrors};
use util\cmd\Console;

$c= new MongoConnection($dsn);
try {
  $c->collection('test.entries')->upsert(['test' => true], [
    '$inc' => ['version' => 1],
    '$setOnInsert' => ['version' => 1],
  ]);
} catch (WriteErrors $errors) {
  Console::writeLine('The following errors occurred: ', $errors->list());
}
```

## See also

* #54
* https://www.mongodb.com/docs/manual/reference/command/update/#mongodb-data-update.writeErrors
* https://www.php.net/manual/en/mongodb-driver-writeresult.getwriteerrors.php