### PR TITLE
Add Document::create() which creates a document with an object ID

### DIFF
--- a/src/main/php/com/mongodb/Document.class.php
+++ b/src/main/php/com/mongodb/Document.class.php
@@ -10,6 +10,14 @@ class Document implements Value, ArrayAccess, IteratorAggregate {
   /** @param [:var] */
   public function __construct($properties= []) { $this->properties= $properties; }
 
+  /** @param [:var]|self $from */
+  public static function create($from= []): self {
+    return new self(['_id' => ObjectId::create()] + ($from instanceof self
+      ? $from->properties
+      : (array)$from
+    ));
+  }
+
   /** @return string|com.mongodb.ObjectId */
   public function id() { return $this->properties['_id'] ?: null; }
 

--- a/src/test/php/com/mongodb/unittest/DocumentTest.class.php
+++ b/src/test/php/com/mongodb/unittest/DocumentTest.class.php
@@ -114,4 +114,35 @@ class DocumentTest {
     $fixture['properties']['price']= 12.99;
     Assert::equals(['color' => 'green', 'price' => 12.99], $fixture['properties']);
   }
+
+  #[Test]
+  public function create() {
+    Assert::instance(ObjectId::class, Document::create()->id());
+  }
+
+  #[Test]
+  public function create_with_properties() {
+    $fixture= Document::create(['test' => true]);
+
+    Assert::instance(ObjectId::class, $fixture->id());
+    Assert::true($fixture['test']);
+  }
+
+  #[Test]
+  public function create_passed_id_is_overwritten() {
+    $id= new ObjectId(self::OID);
+    $fixture= Document::create(['_id' => $id]);
+
+    Assert::notEquals($id, $fixture->id());
+  }
+
+  #[Test]
+  public function create_copies_document() {
+    $original= new Document(['_id' => new ObjectId(self::OID), 'test' => true]);
+    $fixture= Document::create($original);
+    $original['test']= false;
+
+    Assert::notEquals($original->id(), $fixture->id());
+    Assert::true($fixture['test']);
+  }
 }


### PR DESCRIPTION
Implements feature suggested in #47

```php
use com\mongodb\Document;

// Creates a document without object ID
$chat= new Document(['topic' => 'Test', 'owner' => $identity]);

// Creates a document with a new object ID
$chat= Document::create(['topic' => 'Test', 'owner' => $identity]);

// Creates a (shallow) copy of the given document, assigning a new object ID
$copy= Document::create($chat);
```