### PR TITLE
Add query API to collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,28 @@ use com\mongodb\{MongoConnection, ObjectId};
 use util\cmd\Console;
 
 $c= new MongoConnection('mongodb://localhost');
-$id= new ObjectId(...);
+$id= new ObjectId('...');
 
 // Find all documents
-$cursor= $c->collection('test.products')->find();
+$cursor= $c->collection('test.products')->query();
 
 // Find document with the specified ID
-$cursor= $c->collection('test.products')->find($id);
+$cursor= $c->collection('test.products')->query($id);
 
 // Find all documents with a name of "Test"
-$cursor= $c->collection('test.products')->find(['name' => 'Test']);
+$cursor= $c->collection('test.products')->query(['name' => 'Test']);
+
+// Use aggregation pipelines
+$cursor= $c->collection('test.products')->query([
+  ['$match' => ['color' => 'green', 'state' => 'ACTIVE']],
+  ['$lookup' => [
+    'from'         => 'users',
+    'localField'   => 'owner.id',
+    'foreignField' => '_id',
+    'as'           => 'owner',
+  ]],
+  ['$addFields' => ['owner' => ['$first' => '$owner']]],
+]);
 
 foreach ($cursor as $document) {
   Console::writeLine('>> ', $document);
@@ -62,7 +74,7 @@ use com\mongodb\{MongoConnection, ObjectId};
 use util\cmd\Console;
 
 $c= new MongoConnection('mongodb://localhost');
-$id= new ObjectId(...);
+$id= new ObjectId('...');
 
 // Select a single document for updating by its ID
 $result= $c->collection('test.products')->update($id, ['$inc' => ['qty' => 1]]);
@@ -102,7 +114,7 @@ use com\mongodb\{MongoConnection, ObjectId};
 use util\cmd\Console;
 
 $c= new MongoConnection('mongodb://localhost');
-$id= new ObjectId(...);
+$id= new ObjectId('...');
 
 // Select a single document to be removed
 $result= $c->collection('test.products')->delete($id);

--- a/src/main/php/com/mongodb/Collection.class.php
+++ b/src/main/php/com/mongodb/Collection.class.php
@@ -281,15 +281,13 @@ class Collection implements Value {
   /**
    * Runs a query and returns a cursor.
    *
-   * @param  ?string|com.mongodb.ObjectId|[:var]|[:var][] $query
+   * @param  string|com.mongodb.ObjectId|[:var]|[:var][] $query
    * @param  com.mongodb.Options... $options
    * @return com.mongodb.result.Cursor
    * @throws com.mongodb.Error
    */
-  public function query($query= null, Options... $options) {
-    if (null === $query) {
-      return $this->find([], ...$options);
-    } else if (is_array($query) && 0 === key($query)) {
+  public function query($query= [], Options... $options) {
+    if (is_array($query) && 0 === key($query)) {
       return $this->aggregate($query, ...$options);
     } else {
       return $this->find($query, ...$options);
@@ -305,7 +303,7 @@ class Collection implements Value {
    * @return ?com.mongodb.Document
    * @throws com.mongodb.Error
    */
-  public function first($query= null, Options... $options) {
+  public function first($query= [], Options... $options) {
     return $this->query($query, ...$options)->first();
   }
 

--- a/src/main/php/com/mongodb/Collection.class.php
+++ b/src/main/php/com/mongodb/Collection.class.php
@@ -293,7 +293,8 @@ class Collection implements Value {
    * @throws com.mongodb.Error
    */
   public function query($query= [], Options... $options) {
-    if (is_array($query) && 0 === key($query)) {
+    $array= is_array($query);
+    if ($array && 0 === key($query)) {
       $sections= [
         'aggregate' => $this->name,
         'pipeline'  => $query,
@@ -303,7 +304,7 @@ class Collection implements Value {
     } else {
       $sections= [
         'find'   => $this->name,
-        'filter' => is_array($query) ? ($query ?: (object)[]) : ['_id' => $query],
+        'filter' => $array ? ($query ?: (object)[]) : ['_id' => $query],
         '$db'    => $this->database,
       ];
     }

--- a/src/main/php/com/mongodb/Collection.class.php
+++ b/src/main/php/com/mongodb/Collection.class.php
@@ -9,6 +9,7 @@ use util\Objects;
  * A collection inside a database.
  *
  * @test  com.mongodb.unittest.CollectionTest
+ * @test  com.mongodb.unittest.CollectionQueryTest
  */
 class Collection implements Value {
   private $proto, $database, $name;
@@ -275,6 +276,37 @@ class Collection implements Value {
 
     $result= $commands->send($options, $sections);
     return new Cursor($commands, $options, $result['body']['cursor']);
+  }
+
+  /**
+   * Runs a query and returns a cursor.
+   *
+   * @param  ?string|com.mongodb.ObjectId|[:var]|[:var][] $query
+   * @param  com.mongodb.Options... $options
+   * @return com.mongodb.result.Cursor
+   * @throws com.mongodb.Error
+   */
+  public function query($query= null, Options... $options) {
+    if (null === $query) {
+      return $this->find([], ...$options);
+    } else if (is_array($query) && 0 === key($query)) {
+      return $this->aggregate($query, ...$options);
+    } else {
+      return $this->find($query, ...$options);
+    }
+  }
+
+  /**
+   * Returns the first document for a given query, or NULL. Shorthand
+   * for running `$collection->query($query)->first()`.
+   *
+   * @param  ?string|com.mongodb.ObjectId|[:var]|[:var][] $query
+   * @param  com.mongodb.Options... $options
+   * @return ?com.mongodb.Document
+   * @throws com.mongodb.Error
+   */
+  public function first($query= null, Options... $options) {
+    return $this->query($query, ...$options)->first();
   }
 
   /**

--- a/src/main/php/com/mongodb/Collection.class.php
+++ b/src/main/php/com/mongodb/Collection.class.php
@@ -279,7 +279,13 @@ class Collection implements Value {
   }
 
   /**
-   * Runs a query and returns a cursor.
+   * Runs a query and returns a cursor. The query may either be a string
+   * or an object ID, in which case the `_id` member is matched, a map of
+   * fields and match values which is passed to `find`, or an aggregation
+   * pipeline.
+   *
+   * Note: The pipeline may not contain `$merge` or `$out` stages, this
+   * method always uses read context for sending the query!
    *
    * @param  string|com.mongodb.ObjectId|[:var]|[:var][] $query
    * @param  com.mongodb.Options... $options
@@ -289,16 +295,16 @@ class Collection implements Value {
   public function query($query= [], Options... $options) {
     if (is_array($query) && 0 === key($query)) {
       $sections= [
-       'aggregate' => $this->name,
-       'pipeline'  => $query,
-       'cursor'    => (object)[],
-       '$db'       => $this->database,
+        'aggregate' => $this->name,
+        'pipeline'  => $query,
+        'cursor'    => (object)[],
+        '$db'       => $this->database,
       ];
     } else {
       $sections= [
-       'find'   => $this->name,
-       'filter' => is_array($query) ? ($query ?: (object)[]) : ['_id' => $query],
-       '$db'    => $this->database,
+        'find'   => $this->name,
+        'filter' => is_array($query) ? ($query ?: (object)[]) : ['_id' => $query],
+        '$db'    => $this->database,
       ];
     }
 

--- a/src/test/php/com/mongodb/unittest/CollectionQueryTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionQueryTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb\unittest;
 
 use com\mongodb\{Collection, Document};
-use test\{Assert, Test};
+use test\{Assert, Test, Values};
 
 class CollectionQueryTest {
   use WireTesting;
@@ -40,6 +40,19 @@ class CollectionQueryTest {
     Assert::equals(
       new Document(self::FIRST),
       (new Collection($protocol, 'testing', 'tests'))->first()
+    );
+    Assert::equals(
+      ['find' => 'tests', 'filter' => (object)[]] + self::QUERY,
+      current($protocol->connections())->command(1)
+    );
+  }
+
+  #[Test, Values([[null], [[]]])]
+  public function first_with_empty($query) {
+    $protocol= $this->newFixture($this->cursor(self::DOCUMENTS));
+    Assert::equals(
+      new Document(self::FIRST),
+      (new Collection($protocol, 'testing', 'tests'))->first($query)
     );
     Assert::equals(
       ['find' => 'tests', 'filter' => (object)[]] + self::QUERY,

--- a/src/test/php/com/mongodb/unittest/CollectionQueryTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionQueryTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb\unittest;
 
 use com\mongodb\{Collection, Document};
-use test\{Assert, Test, Values};
+use test\{Assert, Test};
 
 class CollectionQueryTest {
   use WireTesting;
@@ -47,12 +47,12 @@ class CollectionQueryTest {
     );
   }
 
-  #[Test, Values([[null], [[]]])]
-  public function first_with_empty($query) {
+  #[Test]
+  public function first_with_empty() {
     $protocol= $this->newFixture($this->cursor(self::DOCUMENTS));
     Assert::equals(
       new Document(self::FIRST),
-      (new Collection($protocol, 'testing', 'tests'))->first($query)
+      (new Collection($protocol, 'testing', 'tests'))->first([])
     );
     Assert::equals(
       ['find' => 'tests', 'filter' => (object)[]] + self::QUERY,

--- a/src/test/php/com/mongodb/unittest/CollectionQueryTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CollectionQueryTest.class.php
@@ -1,0 +1,95 @@
+<?php namespace com\mongodb\unittest;
+
+use com\mongodb\{Collection, Document};
+use test\{Assert, Test};
+
+class CollectionQueryTest {
+  use WireTesting;
+
+  const FIRST= ['_id' => 'one', 'name' => 'A'];
+  const SECOND= ['_id' => 'one', 'name' => 'A'];
+  const DOCUMENTS= [self::FIRST, self::SECOND];
+  const QUERY= ['$db' => 'testing', '$readPreference' => ['mode' => 'primary']];
+
+  /**
+   * Returns a new fixture
+   *
+   * @param  var... $messages
+   * @return com.mongodb.io.Protocol
+   */
+  private function newFixture(... $messages) {
+    return $this->protocol([self::$PRIMARY => [$this->hello(self::$PRIMARY), ...$messages]], 'primary')->connect();
+  }
+
+  #[Test]
+  public function query() {
+    $protocol= $this->newFixture($this->cursor(self::DOCUMENTS));
+    Assert::equals(
+      [new Document(self::FIRST), new Document(self::SECOND)],
+      (new Collection($protocol, 'testing', 'tests'))->query()->all()
+    );
+    Assert::equals(
+      ['find' => 'tests', 'filter' => (object)[]] + self::QUERY,
+      current($protocol->connections())->command(1)
+    );
+  }
+
+  #[Test]
+  public function first() {
+    $protocol= $this->newFixture($this->cursor(self::DOCUMENTS));
+    Assert::equals(
+      new Document(self::FIRST),
+      (new Collection($protocol, 'testing', 'tests'))->first()
+    );
+    Assert::equals(
+      ['find' => 'tests', 'filter' => (object)[]] + self::QUERY,
+      current($protocol->connections())->command(1)
+    );
+  }
+
+  #[Test]
+  public function first_with_id() {
+    $protocol= $this->newFixture($this->cursor(self::DOCUMENTS));
+    Assert::equals(
+      new Document(self::FIRST),
+      (new Collection($protocol, 'testing', 'tests'))->first('one')
+    );
+    Assert::equals(
+      ['find' => 'tests', 'filter' => ['_id' => 'one']] + self::QUERY,
+      current($protocol->connections())->command(1)
+    );
+  }
+
+  #[Test]
+  public function first_with_query() {
+    $protocol= $this->newFixture($this->cursor(self::DOCUMENTS));
+    Assert::equals(
+      new Document(self::FIRST),
+      (new Collection($protocol, 'testing', 'tests'))->first(['_id' => 'one'])
+    );
+    Assert::equals(
+      ['find' => 'tests', 'filter' => ['_id' => 'one']] + self::QUERY,
+      current($protocol->connections())->command(1)
+    );
+  }
+
+  #[Test]
+  public function first_with_pipeline() {
+    $pipeline= [['$match' => ['_id' => 'one']]];
+    $protocol= $this->newFixture($this->cursor(self::DOCUMENTS));
+    Assert::equals(
+      new Document(self::FIRST),
+      (new Collection($protocol, 'testing', 'tests'))->first($pipeline)
+    );
+    Assert::equals(
+      ['aggregate' => 'tests', 'pipeline' => $pipeline, 'cursor' => (object)[]] + self::QUERY,
+      current($protocol->connections())->command(1)
+    );
+  }
+
+  #[Test]
+  public function first_without_result() {
+    $protocol= $this->newFixture($this->cursor([]));
+    Assert::null((new Collection($protocol, 'testing', 'tests'))->first());
+  }
+}


### PR DESCRIPTION
This pull request adds two methods to the `com.mongodb.Collection` class, *query()* and *first()*.

* * * 

The *query()* method is liberal in what it accepts:

```php
$cursor= $collection->query();                      // same as ->find()
$cursor= $collection->query([])                     // same as ->find([])
$cursor= $collection->query($objectId);             // same as ->find($objectId)
$cursor= $collection->query(['color' => 'green']);  // same as ->find(['color' => 'green'])
```

* * * 

The *query()* method delegates to *aggregate()* if passed an array of arrays. This allows refactoring queries from simple matching semantics to pipelines easily:

```php
// Before
$cursor= $collection->query(['color' => 'green', 'state' => 'ACTIVE']);

// We decide to join on users
$cursor= $collection->query([
  ['$match' => ['color' => 'green', 'state' => 'ACTIVE']],
  ['$lookup' => [
    'from'         => 'users',
    'localField'   => 'owner.id',
    'foreignField' => '_id',
    'as'           => 'owner',
  ]],
  ['$addFields' => ['owner' => ['$first' => '$owner']]],
]);
```

* * * 

The *first()* method is a shorthand for `query()->first()`. This shortens the common case of writing `$cursor= $collection->aggregate(...); return $cursor->first()` as described in #46:

```php
$document= $collection->first($query);
```


