### PR TITLE
Add fields API to Document

### DIFF
--- a/src/main/php/com/mongodb/Document.class.php
+++ b/src/main/php/com/mongodb/Document.class.php
@@ -86,29 +86,28 @@ class Document implements Value, ArrayAccess, IteratorAggregate {
   }
 
   /**
-   * Sets a map of fields and values
+   * Sets a field to a given value
    *
-   * @param  [:var] $map
+   * @param  string $field
+   * @param  var $value
    * @return self
    */
-  public function with(array $fields) {
-    foreach ($fields as $field => $value) {
-      $ptr= &$this->properties;
-      foreach (explode('.', $field) as $path) {
-        $ptr= &$ptr[$path];
-      }
-      $ptr= $value;
+  public function with($field, $value) {
+    $ptr= &$this->properties;
+    foreach (explode('.', $field) as $path) {
+      $ptr= &$ptr[$path];
     }
+    $ptr= $value;
     return $this;
   }
 
   /**
    * Unsets a list of fields
    *
-   * @param  [:var] $map
+   * @param  string... $fields
    * @return self
    */
-  public function unset(array $fields) {
+  public function unset(... $fields) {
     foreach ($fields as $field) {
       $paths= explode('.', $field);
       $last= array_pop($paths);

--- a/src/main/php/com/mongodb/Document.class.php
+++ b/src/main/php/com/mongodb/Document.class.php
@@ -71,6 +71,56 @@ class Document implements Value, ArrayAccess, IteratorAggregate {
   /** Iterator over all properties */
   public function getIterator(): Traversable { yield from $this->properties; }
 
+  /**
+   * Gets a field. Returns NULL if it did not exist.
+   *
+   * @param  string $field
+   * @return var
+   */
+  public function get($field) {
+    $ptr= &$this->properties;
+    foreach (explode('.', $field) as $path) {
+      $ptr= &$ptr[$path];
+    }
+    return $ptr;
+  }
+
+  /**
+   * Sets a map of fields and values
+   *
+   * @param  [:var] $map
+   * @return self
+   */
+  public function with(array $fields) {
+    foreach ($fields as $field => $value) {
+      $ptr= &$this->properties;
+      foreach (explode('.', $field) as $path) {
+        $ptr= &$ptr[$path];
+      }
+      $ptr= $value;
+    }
+    return $this;
+  }
+
+  /**
+   * Unsets a list of fields
+   *
+   * @param  [:var] $map
+   * @return self
+   */
+  public function unset(array $fields) {
+    foreach ($fields as $field) {
+      $paths= explode('.', $field);
+      $last= array_pop($paths);
+      $ptr= &$this->properties;
+      foreach ($paths as $path) {
+        $ptr= &$ptr[$path];
+      }
+      unset($ptr[$last]);
+    }
+    return $this;
+  }
+
   /** @return string */
   public function hashCode() {
     return 'D'.Objects::hashOf($this->properties);

--- a/src/main/php/com/mongodb/Document.class.php
+++ b/src/main/php/com/mongodb/Document.class.php
@@ -102,6 +102,23 @@ class Document implements Value, ArrayAccess, IteratorAggregate {
   }
 
   /**
+   * Updates this document from a given iterable producing field => value pairs.
+   *
+   * @param  iterable $from
+   * @return self
+   */
+  public function update(iterable $from) {
+    foreach ($from as $field => $value) {
+      $ptr= &$this->properties;
+      foreach (explode('.', $field) as $path) {
+        $ptr= &$ptr[$path];
+      }
+      $ptr= $value;
+    }
+    return $this;
+  }
+
+  /**
    * Unsets a list of fields
    *
    * @param  string... $fields

--- a/src/test/php/com/mongodb/unittest/DocumentTest.class.php
+++ b/src/test/php/com/mongodb/unittest/DocumentTest.class.php
@@ -114,4 +114,28 @@ class DocumentTest {
     $fixture['properties']['price']= 12.99;
     Assert::equals(['color' => 'green', 'price' => 12.99], $fixture['properties']);
   }
+
+  #[Test]
+  public function get() {
+    $fixture= new Document(['topic' => 'Test', 'context' => ['readonly' => true]]);
+
+    Assert::equals('Test', $fixture->get('topic'));
+    Assert::equals(null, $fixture->get('state'));
+    Assert::equals(true, $fixture->get('context.readonly'));
+  }
+
+  #[Test]
+  public function fluent() {
+    $fixture= (new Document(['_id' => 'one', 'connections' => [6100]]))
+      ->with(['topic' => 'Test', 'state' => 'ARCHIVED'])
+      ->with(['state' => 'ACTIVE'])
+      ->with(['context.readonly' => true])
+      ->unset(['_id', 'connections'])
+    ;
+
+    Assert::equals(
+      ['topic' => 'Test', 'state' => 'ACTIVE', 'context' => ['readonly' => true]],
+      $fixture->properties()
+    );
+  }
 }

--- a/src/test/php/com/mongodb/unittest/DocumentTest.class.php
+++ b/src/test/php/com/mongodb/unittest/DocumentTest.class.php
@@ -135,11 +135,11 @@ class DocumentTest {
 
   #[Test]
   public function fluent() {
-    $fixture= (new Document(['_id' => 'one', 'connections' => [6100]]))
-      ->with(['topic' => 'Test', 'state' => 'ARCHIVED'])
-      ->with(['state' => 'ACTIVE'])
-      ->with(['context.readonly' => true])
-      ->unset(['_id', 'connections'])
+    $fixture= (new Document(['_id' => 'one', 'connections' => [6100], 'state' => 'ARCHIVED']))
+      ->with('topic', 'Test')
+      ->with('state', 'ACTIVE')
+      ->with('context.readonly', true)
+      ->unset('_id', 'connections')
     ;
 
     Assert::equals(

--- a/src/test/php/com/mongodb/unittest/DocumentTest.class.php
+++ b/src/test/php/com/mongodb/unittest/DocumentTest.class.php
@@ -120,8 +120,17 @@ class DocumentTest {
     $fixture= new Document(['topic' => 'Test', 'context' => ['readonly' => true]]);
 
     Assert::equals('Test', $fixture->get('topic'));
-    Assert::equals(null, $fixture->get('state'));
     Assert::equals(true, $fixture->get('context.readonly'));
+    Assert::equals(null, $fixture->get('state'));
+    Assert::equals(null, $fixture->get('context.owner'));
+  }
+
+  #[Test]
+  public function get_non_existant() {
+    $fixture= new Document(['topic' => 'Test', 'context' => ['readonly' => true]]);
+
+    Assert::equals(null, $fixture->get('state'));
+    Assert::equals(null, $fixture->get('context.owner'));
   }
 
   #[Test]


### PR DESCRIPTION
This pull request adds 3 methods to the `com.mongodb.Document` class, *get()*, *with()* and *unset()*. All of these operate on fields instead of property names, the difference being that the field `context.readonly` references a *context* object's *readonly*  property, where as property names are unparsed.

## Accessing fields

```php
use com\mongodb\Document;

$doc= new Document(['topic' => 'Test', 'context' => ['readonly' => true]]);

$fixture->get('topic');             // "Test", like $fixture['topic']
$fixture->get('context.readonly');  // true, like $fixture['context']['readonly']
$fixture->get('state');             // null, like $fixture['state'] ?? null
```

## Modifying fields

```php
use com\mongodb\Document;

$doc= $collection->find(['name' => 'Test']);

// Create a copy of this document
$collection->insert($doc
  ->unset('_id')
  ->with('name', 'Copy of '.$doc['name'])
  ->update(['updated' => $now, 'owner' => $user])
);
```
