### PR TITLE
Remove legacy opcodes except OP_QUERY and OP_REPLY, used by "hello"

### DIFF
--- a/src/main/php/com/mongodb/io/Connection.class.php
+++ b/src/main/php/com/mongodb/io/Connection.class.php
@@ -97,7 +97,7 @@ class Connection {
         'application' => ['name' => $options['params']['appName'] ?? $_SERVER['argv'][0] ?? 'php'],
         'driver'      => ['name' => 'XP MongoDB Connectivity', 'version' => '3.0.0'],
         'os'          => ['name' => php_uname('s'), 'type' => PHP_OS, 'architecture' => php_uname('m'), 'version' => php_uname('r')]
-      ]
+      ],
     ];
 
     // If the optional field saslSupportedMechs is specified, the command also returns
@@ -159,7 +159,7 @@ class Connection {
       );
       $document= &$reply['documents'][0];
 
-      // See https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#type
+      // See https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md#type
       if ($document['ok'] ?? false) {
         if (isset($document['isreplicaset'])) {
           $kind= self::RSGhost;

--- a/src/main/php/com/mongodb/io/Connection.class.php
+++ b/src/main/php/com/mongodb/io/Connection.class.php
@@ -9,18 +9,15 @@ use util\{Secret, Objects};
  * A single connection to MongoDB server, of which more than one may exist
  * in the Protocol class based on read preference.
  *
+ * @see   https://www.mongodb.com/docs/manual/reference/mongodb-wire-protocol/
  * @see   https://docs.mongodb.com/manual/core/read-preference-mechanics/
  * @test  com.mongodb.unittest.ConnectionTest
  */
 class Connection {
   const OP_REPLY        = 1;
-  const OP_UPDATE       = 2001;
-  const OP_INSERT       = 2002;
   const OP_QUERY        = 2004;
-  const OP_GET_MORE     = 2005;
-  const OP_DELETE       = 2006;
-  const OP_KILL_CURSORS = 2007;
   const OP_MSG          = 2013;
+  const OP_COMPRESSED   = 2012;
 
   const RSGhost         = 'RSGhost';
   const RSPrimary       = 'RSPrimary';


### PR DESCRIPTION
> Starting in MongoDB 5.1, [OP_MSG](https://www.mongodb.com/docs/manual/reference/mongodb-wire-protocol/#std-label-wire-op-msg) and [OP_COMPRESSED](https://www.mongodb.com/docs/manual/reference/mongodb-wire-protocol/#std-label-wire-op-compressed) are the only supported opcodes to send requests to a MongoDB server.

See https://www.mongodb.com/docs/manual/reference/mongodb-wire-protocol/#legacy-opcodes