### PR TITLE
Implement compression

### DIFF
--- a/src/main/php/com/mongodb/io/Compression.class.php
+++ b/src/main/php/com/mongodb/io/Compression.class.php
@@ -17,7 +17,7 @@ class Compression implements Value {
 
   static function __static() {
     extension_loaded('zlib') && self::$negotiable['zlib']= fn($options) => new Zlib($options['zlibCompressionLevel'] ?? -1);
-    extension_loaded('zstd') && self::$negotiable['zstd']= fn($options) => new Zstd();
+    extension_loaded('zstd') && self::$negotiable['zstd']= fn($options) => new Zstd($options['zstdCompressionLevel'] ?? -1);
   }
 
   /** @param [:com.mongodb.io.Compressor] $compressors */

--- a/src/main/php/com/mongodb/io/Compression.class.php
+++ b/src/main/php/com/mongodb/io/Compression.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb\io;
 
 use lang\Value;
-use util\{Comparison, Objects};
+use util\Comparison;
 
 /** 
  * Compression negotiation and selection.
@@ -89,6 +89,10 @@ class Compression implements Value {
 
   /** @return string */
   public function toString() {
-    return nameof($this).'@'.Objects::stringOf($this->compressors);
+    $s= nameof($this)."@[\n";
+    foreach ($this->compressors as $compressor) {
+      $s.= '  '.$compressor->toString()."\n";
+    }
+    return $s.']';
   }
 }

--- a/src/main/php/com/mongodb/io/Compression.class.php
+++ b/src/main/php/com/mongodb/io/Compression.class.php
@@ -83,7 +83,8 @@ class Compression implements Value {
       isset($sections['copydb'])
     )) return null;
 
-    // Currently always select the first compressor negotiated
+    // When compressing, clients MUST use the first compressor in the client's
+    // configured compressors list that is also in the servers list.
     return current($this->compressors);
   }
 

--- a/src/main/php/com/mongodb/io/Compression.class.php
+++ b/src/main/php/com/mongodb/io/Compression.class.php
@@ -12,6 +12,7 @@ class Compression {
 
   static function __static() {
     extension_loaded('zlib') && self::$negotiable['zlib']= fn($options) => new Zlib($options['zlibCompressionLevel'] ?? -1);
+    extension_loaded('zstd') && self::$negotiable['zstd']= fn($options) => new Zstd();
   }
 
   /** @param [:com.mongodb.io.Compressor] $compressors */

--- a/src/main/php/com/mongodb/io/Compression.class.php
+++ b/src/main/php/com/mongodb/io/Compression.class.php
@@ -1,0 +1,83 @@
+<?php namespace com\mongodb\io;
+
+/** 
+ * Compression negotiation and selection.
+ * 
+ * @see   https://github.com/mongodb/specifications/blob/master/source/compression/OP_COMPRESSED.md
+ * @test  com.mongodb.unittest.CompressionTest
+ */
+class Compression {
+  private static $negotiable= [];
+  private $compressors;
+
+  static function __static() {
+    extension_loaded('zlib') && self::$negotiable['zlib']= fn($options) => new Zlib($options['zlibCompressionLevel'] ?? -1);
+  }
+
+  /** @param [:com.mongodb.io.Compressor] $compressors */
+  public function __construct(array $compressors= []) {
+    $this->compressors= $compressors;
+  }
+
+  /** Registers a given compressor */
+  public function with(Compressor $compressor): self {
+    $this->compressors[$compressor->id]= $compressor;
+    return $this;
+  }
+
+  /**
+   * Negotiate compression. Returns NULL if no compressors apply.
+   * 
+   * @param  string[] $server
+   * @param  [:string] $options
+   * @return ?self
+   */
+  public static function negotiate($server, $options= []) {
+    $negotiated= [];
+    foreach ($server as $preference) {
+      if ($new= self::$negotiable[$preference] ?? null) {
+        $compressor= $new($options);
+        $negotiated[$compressor->id]= $compressor;
+      }
+    }
+    return $negotiated ? new self($negotiated) : null;
+  }
+
+  /**
+   * Selects the compressor for a given ID. Returns NULL if compressor by this
+   * ID is present.
+   *
+   * @param  int $id
+   * @return ?com.mongodb.io.Compressor
+   */
+  public function select($id) {
+    return $this->compressors[$id] ?? null;
+  }
+
+  /**
+   * Returns compressor for given input sections and length. Returns NULL if no
+   * compression should be used.
+   *
+   * @param  [:var] $sectionts
+   * @param  int $length
+   * @return ?com.mongodb.io.Compressor
+   */
+  public function for($sections, $length) {
+    if (empty($this->compressors) || (
+      isset($sections['hello']) ||
+      isset($sections['isMaster']) ||
+      isset($sections['saslStart']) ||
+      isset($sections['saslContinue']) ||
+      isset($sections['getnonce']) ||
+      isset($sections['authenticate']) ||
+      isset($sections['createUser']) ||
+      isset($sections['updateUser']) ||
+      isset($sections['copydbSaslStart']) ||
+      isset($sections['copydbgetnonce']) ||
+      isset($sections['copydb'])
+    )) return null;
+
+    // Currently always select the first compressor negotiated
+    return current($this->compressors);
+  }
+}

--- a/src/main/php/com/mongodb/io/Compression.class.php
+++ b/src/main/php/com/mongodb/io/Compression.class.php
@@ -1,12 +1,17 @@
 <?php namespace com\mongodb\io;
 
+use lang\Value;
+use util\{Comparison, Objects};
+
 /** 
  * Compression negotiation and selection.
  * 
  * @see   https://github.com/mongodb/specifications/blob/master/source/compression/OP_COMPRESSED.md
  * @test  com.mongodb.unittest.CompressionTest
  */
-class Compression {
+class Compression implements Value {
+  use Comparison;
+
   private static $negotiable= [];
   private $compressors;
 
@@ -80,5 +85,10 @@ class Compression {
 
     // Currently always select the first compressor negotiated
     return current($this->compressors);
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'@'.Objects::stringOf($this->compressors);
   }
 }

--- a/src/main/php/com/mongodb/io/Compressor.class.php
+++ b/src/main/php/com/mongodb/io/Compressor.class.php
@@ -1,10 +1,15 @@
 <?php namespace com\mongodb\io;
 
-abstract class Compressor {
+use lang\Value;
+
+abstract class Compressor implements Value {
   public $id;
 
   public abstract function compress($data);
 
   public abstract function decompress($compressed);
 
+  public function hashCode() { return 'C'.$this->id; }
+
+  public function compareTo($value) { return $value instanceof self ? $this->id <=> $value->id : 1; }
 }

--- a/src/main/php/com/mongodb/io/Compressor.class.php
+++ b/src/main/php/com/mongodb/io/Compressor.class.php
@@ -9,7 +9,7 @@ abstract class Compressor implements Value {
 
   public abstract function decompress($compressed);
 
-  public function toString() { return nameof($this).'#'.$this->id; }
+  public function toString() { return nameof($this).'(id: '.$this->id.')'; }
 
   public function hashCode() { return 'C'.$this->id; }
 

--- a/src/main/php/com/mongodb/io/Compressor.class.php
+++ b/src/main/php/com/mongodb/io/Compressor.class.php
@@ -9,7 +9,10 @@ abstract class Compressor implements Value {
 
   public abstract function decompress($compressed);
 
+  public function toString() { return nameof($this).'#'.$this->id; }
+
   public function hashCode() { return 'C'.$this->id; }
 
   public function compareTo($value) { return $value instanceof self ? $this->id <=> $value->id : 1; }
+
 }

--- a/src/main/php/com/mongodb/io/Compressor.class.php
+++ b/src/main/php/com/mongodb/io/Compressor.class.php
@@ -1,0 +1,10 @@
+<?php namespace com\mongodb\io;
+
+abstract class Compressor {
+  public $id;
+
+  public abstract function compress($data);
+
+  public abstract function decompress($compressed);
+
+}

--- a/src/main/php/com/mongodb/io/Connection.class.php
+++ b/src/main/php/com/mongodb/io/Connection.class.php
@@ -99,6 +99,10 @@ class Connection {
         'driver'      => ['name' => 'XP MongoDB Connectivity', 'version' => '3.0.0'],
         'os'          => ['name' => php_uname('s'), 'type' => PHP_OS, 'architecture' => php_uname('m'), 'version' => php_uname('r')]
       ],
+      'compression' => ($param= ($options['params']['compressors'] ?? null))
+        ? explode(',', $param)
+        : []
+      ,
     ];
 
     // If the optional field saslSupportedMechs is specified, the command also returns
@@ -110,10 +114,6 @@ class Connection {
       $params['saslSupportedMechs']= "{$authSource}.{$user}";
     } else {
       $authSource= null;
-    }
-
-    if ($compressors= ($options['params']['compressors'] ?? null)) {
-      $params['compression']= explode(',', $compressors);
     }
 
     try {

--- a/src/main/php/com/mongodb/io/Zlib.class.php
+++ b/src/main/php/com/mongodb/io/Zlib.class.php
@@ -16,4 +16,9 @@ class Zlib extends Compressor {
   public function decompress($compressed) {
     return gzuncompress($compressed);
   }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'(id: '.$this->id.', level: '.$this->level.')';
+  }
 }

--- a/src/main/php/com/mongodb/io/Zlib.class.php
+++ b/src/main/php/com/mongodb/io/Zlib.class.php
@@ -1,0 +1,18 @@
+<?php namespace com\mongodb\io;
+
+class Zlib extends Compressor {
+  public $id= 2;
+  public $level;
+
+  public function __construct($level) {
+    $this->level= $level;
+  }
+
+  public function compress($data) {
+    return gzcompress($data, $this->level);
+  }
+
+  public function decompress($compressed) {
+    return gzuncompress($compressed);
+  }
+}

--- a/src/main/php/com/mongodb/io/Zlib.class.php
+++ b/src/main/php/com/mongodb/io/Zlib.class.php
@@ -4,7 +4,8 @@ class Zlib extends Compressor {
   public $id= 2;
   public $level;
 
-  public function __construct($level) {
+  /** @param int $level */
+  public function __construct($level= -1) {
     $this->level= $level;
   }
 

--- a/src/main/php/com/mongodb/io/Zstd.class.php
+++ b/src/main/php/com/mongodb/io/Zstd.class.php
@@ -1,0 +1,19 @@
+<?php namespace com\mongodb\io;
+
+class Zstd extends Compressor {
+  public $id= 2;
+  public $level;
+
+  /** @param int $level */
+  public function __construct($level= -1) {
+    $this->level= $level;
+  }
+
+  public function compress($data) {
+    return zstd_compress($data, $this->level);
+  }
+
+  public function decompress($compressed) {
+    return zstd_uncompress($compressed);
+  }
+}

--- a/src/main/php/com/mongodb/io/Zstd.class.php
+++ b/src/main/php/com/mongodb/io/Zstd.class.php
@@ -2,15 +2,9 @@
 
 class Zstd extends Compressor {
   public $id= 3;
-  public $level;
-
-  /** @param int $level */
-  public function __construct($level= -1) {
-    $this->level= $level;
-  }
 
   public function compress($data) {
-    return zstd_compress($data, $this->level);
+    return zstd_compress($data);
   }
 
   public function decompress($compressed) {

--- a/src/main/php/com/mongodb/io/Zstd.class.php
+++ b/src/main/php/com/mongodb/io/Zstd.class.php
@@ -16,4 +16,9 @@ class Zstd extends Compressor {
   public function decompress($compressed) {
     return zstd_uncompress($compressed);
   }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'(id: '.$this->id.', level: '.$this->level.')';
+  }
 }

--- a/src/main/php/com/mongodb/io/Zstd.class.php
+++ b/src/main/php/com/mongodb/io/Zstd.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb\io;
 
 class Zstd extends Compressor {
-  public $id= 2;
+  public $id= 3;
   public $level;
 
   /** @param int $level */

--- a/src/main/php/com/mongodb/io/Zstd.class.php
+++ b/src/main/php/com/mongodb/io/Zstd.class.php
@@ -10,9 +10,4 @@ class Zstd extends Compressor {
   public function decompress($compressed) {
     return zstd_uncompress($compressed);
   }
-
-  /** @return string */
-  public function toString() {
-    return nameof($this).'(id: '.$this->id.', level: '.$this->level.')';
-  }
 }

--- a/src/main/php/com/mongodb/io/Zstd.class.php
+++ b/src/main/php/com/mongodb/io/Zstd.class.php
@@ -2,6 +2,12 @@
 
 class Zstd extends Compressor {
   public $id= 3;
+  public $level;
+
+  /** @param int $level */
+  public function __construct($level= -1) {
+    $this->level= $level;
+  }
 
   public function compress($data) {
     return zstd_compress($data);
@@ -9,5 +15,10 @@ class Zstd extends Compressor {
 
   public function decompress($compressed) {
     return zstd_uncompress($compressed);
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'(id: '.$this->id.', level: '.$this->level.')';
   }
 }

--- a/src/test/php/com/mongodb/unittest/CompressionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CompressionTest.class.php
@@ -74,4 +74,12 @@ class CompressionTest {
   public function negotiate_zstd() {
     Assert::instance(Zstd::class, Compression::negotiate(['unsupported', 'zstd'])->select(3));
   }
+
+  #[Test, Runtime(extensions: ['zstd']), Values([[[], -1], [['zstdCompressionLevel' => 6], 6]])]
+  public function negotiate_zstd_with($options, $level) {
+    $compressor= Compression::negotiate(['zstd'], $options)->select(3);
+
+    Assert::instance(Zstd::class, $compressor);
+    Assert::equals($level, $compressor->level);
+  }
 }

--- a/src/test/php/com/mongodb/unittest/CompressionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CompressionTest.class.php
@@ -1,0 +1,72 @@
+<?php namespace com\mongodb\unittest;
+
+use com\mongodb\io\{Compression, Compressor, Zlib};
+use test\verify\Runtime;
+use test\{Assert, Before, Test, Values};
+
+class CompressionTest {
+  private $compressor;
+
+  #[Before]
+  public function compressor() {
+    $this->compressor= new class() extends Compressor {
+      public $id= 9;
+      public function compress($data) { /** Not implemented */ }
+      public function decompress($compressed) { /** Not implemented */ }
+    };
+  }
+
+
+  #[Test]
+  public function can_create() {
+    new Compression();
+  }
+
+  #[Test]
+  public function select() {
+    Assert::equals($this->compressor, (new Compression())->with($this->compressor)->select($this->compressor->id));
+  }
+
+  #[Test]
+  public function select_empty() {
+    Assert::null((new Compression())->select($this->compressor->id));
+  }
+
+  #[Test]
+  public function select_non_existant() {
+    Assert::null((new Compression())->with($this->compressor)->select(2));
+  }
+
+  #[Test]
+  public function not_for_hello() {
+    Assert::null((new Compression())->with($this->compressor)->for(['hello' => 1], 128));
+  }
+
+  #[Test]
+  public function for_insert() {
+    Assert::equals($this->compressor, (new Compression())->with($this->compressor)->for(['insert' => 'collection'], 1024));
+  }
+
+  #[Test]
+  public function negotiate_empty() {
+    Assert::null(Compression::negotiate([]));
+  }
+
+  #[Test]
+  public function negotiate_unsupported() {
+    Assert::null(Compression::negotiate(['unsupported']));
+  }
+
+  #[Test, Runtime(extensions: ['zlib'])]
+  public function negotiate_zlib() {
+    Assert::instance(Zlib::class, Compression::negotiate(['unsupported', 'zlib'])->select(2));
+  }
+
+  #[Test, Runtime(extensions: ['zlib']), Values([[[], -1], [['zlibCompressionLevel' => 6], 6]])]
+  public function negotiate_zlib_with($options, $level) {
+    $compressor= Compression::negotiate(['zlib'], $options)->select(2);
+
+    Assert::instance(Zlib::class, $compressor);
+    Assert::equals($level, $compressor->level);
+  }
+}

--- a/src/test/php/com/mongodb/unittest/CompressionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CompressionTest.class.php
@@ -72,6 +72,6 @@ class CompressionTest {
 
   #[Test, Runtime(extensions: ['zstd'])]
   public function negotiate_zstd() {
-    Assert::instance(Zstd::class, Compression::negotiate(['unsupported', 'zstd'])->select(2));
+    Assert::instance(Zstd::class, Compression::negotiate(['unsupported', 'zstd'])->select(3));
   }
 }

--- a/src/test/php/com/mongodb/unittest/CompressionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/CompressionTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\mongodb\unittest;
 
-use com\mongodb\io\{Compression, Compressor, Zlib};
+use com\mongodb\io\{Compression, Compressor, Zlib, Zstd};
 use test\verify\Runtime;
 use test\{Assert, Before, Test, Values};
 
@@ -68,5 +68,10 @@ class CompressionTest {
 
     Assert::instance(Zlib::class, $compressor);
     Assert::equals($level, $compressor->level);
+  }
+
+  #[Test, Runtime(extensions: ['zstd'])]
+  public function negotiate_zstd() {
+    Assert::instance(Zstd::class, Compression::negotiate(['unsupported', 'zstd'])->select(2));
   }
 }

--- a/src/test/php/com/mongodb/unittest/ConnectionTest.class.php
+++ b/src/test/php/com/mongodb/unittest/ConnectionTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace com\mongodb\unittest;
 
+use com\mongodb\Int64;
 use com\mongodb\io\{BSON, Connection, Compression};
 use peer\ConnectException;
 use test\verify\Runtime;
@@ -15,6 +16,25 @@ class ConnectionTest {
     return [
       pack('VVVV', strlen($payload) + 36, 0, 0, Connection::OP_REPLY),
       pack('VPVV', 0, 0, 0, 1).$payload
+    ];
+  }
+
+  /** Creates an OP_MSG message */
+  private function msg(array $document): array {
+    $payload= $this->bson->sections($document);
+    return [
+      pack('VVVV', strlen($payload) + 21, 0, 0, Connection::OP_MSG),
+      pack('VC', 0, 0).$payload
+    ];
+  }
+
+  /** Creates an OP_COMPRESSED message with an embedded OP_MSG opcode */
+  private function compressed(array $document): array {
+    $payload= pack('VC', 0, 0).$this->bson->sections($document);
+    $compressed= gzcompress($payload);
+    return [
+      pack('VVVV', strlen($compressed) + 25, 0, 0, Connection::OP_COMPRESSED),
+      pack('VVC', Connection::OP_MSG, strlen($payload), 2).$compressed
     ];
   }
 
@@ -89,5 +109,37 @@ class ConnectionTest {
     $c->establish();
 
     Assert::instance(Compression::class, $c->compression);
+  }
+
+  #[Test]
+  public function send_and_receive() {
+    $documents= [['_id' => 'one']];
+    $c= new Connection(new TestingSocket([
+      ...$this->reply(['ok' => 1.0]),
+      ...$this->msg([
+        'cursor' => ['firstBatch' => $documents, 'id' => new Int64(0), 'ns' => 'test.entries'],
+        'ok'     => 1,
+      ]),
+    ]));
+    $c->establish();
+    $reply= $c->send(Connection::OP_MSG, "\x00\x00\x00\x00\x00", ['find' => 'entries', '$db' => 'test']);
+
+    Assert::equals($documents, $reply['body']['cursor']['firstBatch']);
+  }
+
+  #[Test, Runtime(extensions: ['zlib'])]
+  public function send_and_receive_compressed() {
+    $documents= [['_id' => 'one']];
+    $c= new Connection(new TestingSocket([
+      ...$this->reply(['ok' => 1.0, 'compression' => ['zlib']]),
+      ...$this->compressed([
+        'cursor' => ['firstBatch' => $documents, 'id' => new Int64(0), 'ns' => 'test.entries'],
+        'ok'     => 1,
+      ]),
+    ]));
+    $c->establish();
+    $reply= $c->send(Connection::OP_MSG, "\x00\x00\x00\x00\x00", ['find' => 'entries', '$db' => 'test']);
+
+    Assert::equals($documents, $reply['body']['cursor']['firstBatch']);
   }
 }

--- a/src/test/php/com/mongodb/unittest/WireTesting.class.php
+++ b/src/test/php/com/mongodb/unittest/WireTesting.class.php
@@ -32,15 +32,16 @@ trait WireTesting {
    * Creates a hello reply
    *
    * @param  string $node
+   * @param  [:var] $fields
    * @return [:var]
    */
-  private function hello($node) {
+  private function hello($node, $fields= []) {
     return [
       'responseFlags'   => 8,
       'cursorID'        => 0,
       'startingFrom'    => 0,
       'numberReturned'  => 1,
-      'documents'       => [[
+      'documents'       => [$fields + [
         'topologyVersion'              => ['processId' => new ObjectId('6235b5ddda38998abb76bed3'), new Int64(6)],
         'hosts'                        => [self::$PRIMARY, self::$SECONDARY1, self::$SECONDARY2],
         'setName'                      => 'atlas-test-shard-0',


### PR DESCRIPTION
Implements feature suggested in https://github.com/xp-forge/mongodb/issues/61

## Supported compressors

* [ ] snappy (1)
* [x] zlib (2) - via https://www.php.net/zlib
* [x] zstd (3) - via https://github.com/kjdev/php-ext-zstd

## Negotiation

To enable compression, add the preferred compressors to the connection URI as follows

```
mongodb://username:password@host/test?compressors=zstd,zlib[&zlibCompressionLevel=6][&zstdCompressionLevel=3]
```

The server will answer with the compressors it supports, which in turn will be matched against the list of PHP extensions loaded. The client will align its preference with the order in which the server returns the compressors.

The compression levels, if not specified, default to `-1`, which will in turn use the defaults for the given compressor.

## Debugging

```php
use com\mongodb\MongoConnection;
use util\cmd\Console;

$c= new MongoConnection($dsn);
$c->connect();

// Compression: com.mongodb.io.Compression@[
//   com.mongodb.io.Zlib(id: 2, level: -1)
//   com.mongodb.io.Zstd(id: 3, level: -1)
// ]
Console::writeLine('Compression: ', current($c->protocol()->connections())->compression);
```