### PR TITLE
Add support for encrypted values

### DIFF
--- a/src/main/php/com/mongodb/Encrypted.class.php
+++ b/src/main/php/com/mongodb/Encrypted.class.php
@@ -1,0 +1,16 @@
+<?php namespace com\mongodb;
+
+class Encrypted {
+  private $ciphertext;
+
+  public function __construct($ciphertext) {
+    $this->ciphertext= (string)$ciphertext;
+  }
+
+  /** @return int */
+  public function length() { return strlen($this->ciphertext); }
+
+  /** @return string */
+  public function ciphertext() { return $this->ciphertext; }
+
+}

--- a/src/test/php/com/mongodb/unittest/BSONTest.class.php
+++ b/src/test/php/com/mongodb/unittest/BSONTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace com\mongodb\unittest;
 
 use com\mongodb\io\BSON;
-use com\mongodb\{Code, Decimal128, Document, Int64, MaxKey, MinKey, ObjectId, Regex, Timestamp};
+use com\mongodb\{Code, Decimal128, Document, Int64, MaxKey, MinKey, ObjectId, Regex, Timestamp, Encrypted};
 use lang\{FormatException, IllegalArgumentException};
 use test\{Assert, Expect, Test, Values};
 use util\{Bytes, Date, UUID};
@@ -60,6 +60,7 @@ class BSONTest {
 
     // Special types
     yield [new Bytes('abc'), "\x05test\x00\x03\x00\x00\x00\x00abc"];
+    yield [new Encrypted('ciphertext'), "\x05test\x00\x0a\x00\x00\x00\x06ciphertext"];
     yield [new Date('2020-08-03 17:41 +0200'), "\x09test\x00\xe0\xae\xfb\xb4\x73\x01\x00\x00"];
     yield [new Date('1969-08-03 17:41 +0200'), "\x09test\x00\xe0\x3e\xbd\xf9\xfc\xff\xff\xff"];
     yield [new Timestamp(1596543032, 1), "\x11test\x00\x01\x00\x00\x00\x38\x50\x29\x5f"];


### PR DESCRIPTION
Step 1 for full queryable encryption, see #18. This pull request maps `com.mongodb.Encrypted` instances to binary subtype 6 (and vice versa). However, no automatic encryption and decryption is performed, implementing this can be done in a separate effort. 